### PR TITLE
Go back to macos-latest

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-12, macos-latest, windows-2019]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Now macos-latest is moved to Arm64, it's also based on macos-14.

See https://github.com/actions/runner-images?tab=readme-ov-file#available-images.

Follow up 3f7e03224f1bc25213f273dc9d9a30a39b3e7e3b.