### PR TITLE
Fix cookies get_dict

### DIFF
--- a/curl_cffi/requests/cookies.py
+++ b/curl_cffi/requests/cookies.py
@@ -273,7 +273,7 @@ class Cookies(MutableMapping[str, str]):
         """
         ret = {}
         for cookie in self.jar:
-            if (domain is None or cookie.name == domain) and (path is None or cookie.path == path):
+            if (domain is None or cookie.domain == domain) and (path is None or cookie.path == path):
                 ret[cookie.name] = cookie.value
         return ret
 

--- a/tests/unittest/test_cookies.py
+++ b/tests/unittest/test_cookies.py
@@ -53,3 +53,15 @@ def test_get_dict():
     assert d["foo"] == "bar"
     assert d["hello"] == "world"
     assert d["a"] == "b"
+
+    c = Cookies()
+    c.set("foo", "bar", domain="example.com")
+    c.set("hello", "world", domain="example.com")
+    c.set("foo", "bar", domain="test.local")
+    d_example = c.get_dict("example.com")
+    d_test = c.get_dict("test.local")
+    assert len(d_example) == 2
+    assert d_example["foo"] == "bar"
+    assert d_example["hello"] == "world"
+    assert len(d_test) == 1
+    assert d_test["foo"] == "bar"


### PR DESCRIPTION
`get_dict()` method is broken, if you want to specify domain.
Requested domain is compared with cookie's name, instead of domain