### PR TITLE
Custom response objects

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -165,10 +165,10 @@ def _update_url_params(url: str, *params_list: Union[Dict, List, Tuple, None]) -
     return new_url
 
 
-def _update_header_line(header_lines: List[str], key: str, value: str):
+def _update_header_line(header_lines: List[str], key: str, value: str, force: bool = False):
     """Update header line list by key value pair."""
     for idx, line in enumerate(header_lines):
-        if line.lower().startswith(key.lower() + ":"):
+        if line.lower().startswith(key.lower() + ":") and force:
             header_lines[idx] = f"{key}: {value}"
             break
     else:  # if not break
@@ -455,14 +455,14 @@ class BaseSession:
 
         # Add content-type if missing
         if json is not None:
-            _update_header_line(header_lines, "Content-Type", "application/json")
+            _update_header_line(header_lines, "Content-Type", "application/json", force=True)
         if isinstance(data, dict) and method != "POST":
             _update_header_line(header_lines, "Content-Type", "application/x-www-form-urlencoded")
         if isinstance(data, (str, bytes)):
             _update_header_line(header_lines, "Content-Type", "application/octet-stream")
 
         # Never send `Expect` header.
-        _update_header_line(header_lines, "Expect", "")
+        _update_header_line(header_lines, "Expect", "", force=True)
 
         c.setopt(CurlOpt.HTTPHEADER, [h.encode() for h in header_lines])
 

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -250,7 +250,7 @@ class BaseSession:
 
         if response_class is None:
             response_class = Response
-        elif issubclass(response_class, Response) is False:
+        elif not issubclass(response_class, Response):
             raise TypeError( "`response_class` must be a subclass of `curl_cffi.requests.models.Response`"
                             f" not of type `{response_class}`" )
         self.response_class = response_class

--- a/examples/custom_response_class.py
+++ b/examples/custom_response_class.py
@@ -1,0 +1,14 @@
+from curl_cffi import requests
+
+class CustomResponse(requests.Response):
+    @property
+    def status(self):
+        return self.status_code
+    
+    def custom_method():
+        return "this is a custom method"
+    
+session = requests.Session(response_class=CustomResponse)
+response: CustomResponse = session.get("http://example.com")
+print(response.status)
+print(response.custom_method())

--- a/examples/custom_response_class.py
+++ b/examples/custom_response_class.py
@@ -1,14 +1,23 @@
 from curl_cffi import requests
+from curl_cffi.curl import Curl, CurlInfo
+from typing import cast
 
 class CustomResponse(requests.Response):
+    def __init__(self, curl: Curl | None = None, request: requests.Request | None = None):
+        super().__init__(curl, request)
+        self.local_port = cast(int, curl.getinfo(CurlInfo.LOCAL_PORT))
+        self.connect_time = cast(float, curl.getinfo(CurlInfo.CONNECT_TIME))
+
     @property
     def status(self):
         return self.status_code
     
-    def custom_method():
+    def custom_method(self):
         return "this is a custom method"
     
 session = requests.Session(response_class=CustomResponse)
 response: CustomResponse = session.get("http://example.com")
-print(response.status)
+print(f"{response.status=}")
 print(response.custom_method())
+print(f"{response.local_port=}")
+print(f"{response.connect_time=}")

--- a/tests/integration/test_response_class.py
+++ b/tests/integration/test_response_class.py
@@ -1,3 +1,4 @@
+import pytest
 from curl_cffi import requests
 
 def test_default_response():
@@ -20,8 +21,5 @@ def test_custom_response():
 class WrongTypeResponse: pass
 
 def test_wrong_type_custom_response():
-    try:
+    with pytest.raises(TypeError):
         requests.Session(response_class=WrongTypeResponse)
-        assert False, "session was created without raising issue for wrong response class type"
-    except TypeError:
-        print("Wrong response class type detected")

--- a/tests/integration/test_response_class.py
+++ b/tests/integration/test_response_class.py
@@ -1,0 +1,27 @@
+from curl_cffi import requests
+
+def test_default_response():
+    response = requests.get("http://example.com")
+    assert type(response) == requests.Response
+    print(response.status_code)
+
+class CustomResponse(requests.Response):
+    @property
+    def status(self):
+        return self.status_code
+    
+def test_custom_response():
+    session = requests.Session(response_class=CustomResponse)
+    response = session.get("http://example.com")
+    assert isinstance(response, CustomResponse)
+    assert hasattr(response, "status")
+    print(response.status)
+
+class WrongTypeResponse: pass
+
+def test_wrong_type_custom_response():
+    try:
+        requests.Session(response_class=WrongTypeResponse)
+        assert False, "session was created without raising issue for wrong response class type"
+    except TypeError:
+        print("Wrong response class type detected")


### PR DESCRIPTION
This is a PR related to #397

Here is the test I did:
```py
>>> from curl_cffi.requests import AsyncSession, Session, Response
>>> import asyncio
>>> 
>>> class MyResponse(Response):
...     def __init__(self, *args, **kwargs):
...         super().__init__(*args, **kwargs)
...     @property
...     def status(self):
...         return self.status_code
... 
>>> async def main():
...     response = await AsyncSession(response_factory=MyResponse).get("https://www.lego.com")
...     print("AsyncSession with MyResponse as custom factory ->", type(response), response.status)
...     response = await AsyncSession().get("https://www.lego.com")
...     print("AsyncSession without custom factory ->", type(response))
...     response = Session(response_factory=MyResponse).get("https://www.lego.com")
...     print("Session with MyResponse as custom factory ->", type(response), response.status)
...     response = Session().get("https://www.lego.com")
...     print("Session without custom factory ->", type(response))
... 
>>> if __name__ == "__main__":
...     asyncio.run(main())
... 
AsyncSession with MyResponse as custom factory -> <class '__main__.MyResponse'> 200
AsyncSession without custom factory -> <class 'curl_cffi.requests.models.Response'>
Session with MyResponse as custom factory -> <class '__main__.MyResponse'> 200
Session without custom factory -> <class 'curl_cffi.requests.models.Response'>
```