### PR TITLE
fix: preserve Headers encoding

### DIFF
--- a/curl_cffi/requests/headers.py
+++ b/curl_cffi/requests/headers.py
@@ -89,6 +89,7 @@ class Headers(MutableMapping[str, Optional[str]]):
             self._list: list[tuple[bytes, bytes, Optional[bytes]]] = []
         elif isinstance(headers, Headers):
             self._list = list(headers._list)
+            encoding = encoding or headers.encoding
         elif isinstance(headers, Mapping):
             self._list = [
                 (

--- a/tests/unittest/test_headers.py
+++ b/tests/unittest/test_headers.py
@@ -40,3 +40,15 @@ def test_none_headers():
     """Allow using None to explictly remove headers"""
     headers = Headers({"Content-Type": None})
     assert headers["content-type"] is None
+
+
+def test_wrapped_headers_preserve_encoding():
+    headers = Headers({"foo": "bar"}, encoding="utf-8")
+    wrapped_headers = Headers(headers)
+    assert wrapped_headers.encoding == "utf-8"
+
+
+def test_wrapped_headers_change_encoding():
+    headers = Headers({"foo": "bar"}, encoding="utf-8")
+    wrapped_headers = Headers(headers, encoding="ascii")
+    assert wrapped_headers.encoding == "ascii"


### PR DESCRIPTION
The `Headers.encoding` gets stripped off in the `BaseSession._set_curl_options` method if the headers are already of type `Headers`. This PR aims to fix this by checking whether the headers are of the expected type.