### PR TITLE
Make Session.cookies a property, use session._cookies for Cookies object

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -241,7 +241,7 @@ class BaseSession:
         response_class: Optional[Type[Response]] = None,
     ):
         self.headers = Headers(headers)
-        self.cookies = Cookies(cookies)
+        self._cookies = Cookies(cookies)
         self.auth = auth
         self.base_url = base_url
         self.params = params
@@ -499,7 +499,7 @@ class BaseSession:
         c.setopt(CurlOpt.COOKIEFILE, b"")  # always enable the curl cookie engine first
         c.setopt(CurlOpt.COOKIELIST, "ALL")  # remove all the old cookies first.
 
-        for morsel in self.cookies.get_cookies_for_curl(req):
+        for morsel in self._cookies.get_cookies_for_curl(req):
             # print("Setting", morsel.to_curl_format())
             curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
         if cookies:
@@ -761,9 +761,9 @@ class BaseSession:
         morsels = [CurlMorsel.from_curl_format(c) for c in c.getinfo(CurlInfo.COOKIELIST)]
         # for l in c.getinfo(CurlInfo.COOKIELIST):
         #     print("Curl Cookies", l.decode())
-        self.cookies.update_cookies_from_curl(morsels)
-        rsp.cookies = self.cookies
-        # print("Cookies after extraction", self.cookies)
+        self._cookies.update_cookies_from_curl(morsels)
+        rsp.cookies = self._cookies
+        # print("Cookies after extraction", self._cookies)
         rsp.primary_ip = cast(bytes, c.getinfo(CurlInfo.PRIMARY_IP)).decode()
         rsp.local_ip = cast(bytes, c.getinfo(CurlInfo.LOCAL_IP)).decode()
         rsp.default_encoding = default_encoding
@@ -779,6 +779,14 @@ class BaseSession:
     def _check_session_closed(self):
         if self._closed:
             raise SessionClosed("Session is closed, cannot send request.")
+
+    @property
+    def cookies(self) -> Cookies:
+        return self._cookies
+
+    @cookies.setter
+    def cookies(self, cookies: CookieTypes) -> None:
+        self._cookies = Cookies(cookies)
 
 
 class Session(BaseSession):


### PR DESCRIPTION
This allows users to replace session.cookies after initialization with any CookieTypes object. This behavior matches httpx and requests, and allows it to be a drop-in replacement even in less typical usecases.

httpx uses property in the same manner:
https://github.com/encode/httpx/blob/47f4a96ffaaaa07dca1614409549b5d7a6e7af49/httpx/_client.py#L317-L326

requests appears to differ at first glance, as it does not use a property, but each request calls merge_cookies, which converts dicts to cookie jars, so it's virtually identical

https://github.com/psf/requests/blob/23540c93cac97c763fe59e843a08fa2825aa80fd/src/requests/sessions.py#L241
https://github.com/psf/requests/blob/23540c93cac97c763fe59e843a08fa2825aa80fd/src/requests/cookies.py#L552-L553