### PR TITLE
refactor: Split WebSocket support into separate sync/async implementations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,8 @@ labels: bug
 
 ---
 
-Please check the following items before reporting a bug, otherwise it may be closed immediately.
+Please check the following items and answer all the questions when reporting a bug, 
+otherwise it will be closed immediately.
 
 - [ ] **This is NOT a site-related "bugs"**, e.g. some site blocks me when using curl_cffi,
     UNLESS it has been verified that the reason is missing pieces in the impersonation.

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.8'
     - name: Lint
       run: |
         pip install mypy ruff

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,7 +23,8 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - run: |
+    - name: Lint
+      run: |
         pip install mypy ruff
         make lint
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-22.04, macos-12, macos-14, windows-2019]
-        os: [ubuntu-22.04, macos-12, macos-14]
+        os: [ubuntu-22.04, macos-13, macos-14]
     steps:
     - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build: .preprocessed
 lint:
 	ruff check --exclude issues
 	ruff format --diff
-	mypy --install-types --non-interactive .
+	mypy --install-types --non-interactive . --exclude 'issues/.*'
 
 format:
 	ruff check --fix

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build: .preprocessed
 	python -m build --wheel
 
 lint:
-	ruff check
+	ruff check --exclude issues
 	ruff format --diff
 	mypy --install-types --non-interactive .
 

--- a/README.md
+++ b/README.md
@@ -200,28 +200,38 @@ async with AsyncSession() as s:
 ### WebSockets
 
 ```python
-from curl_cffi.requests import Session, WebSocket
+from curl_cffi.requests import WebSocket
 
-def on_message(ws: WebSocket, message):
+def on_message(ws: WebSocket, message: str | bytes):
     print(message)
 
-with Session() as s:
-    ws = s.ws_connect(
-        "wss://api.gemini.com/v1/marketdata/BTCUSD",
-        on_message=on_message,
-    )
-    ws.run_forever()
+ws = WebSocket(on_message=on_message)
+ws.run_forever("wss://api.gemini.com/v1/marketdata/BTCUSD")
 ```
 
 For low-level APIs, Scrapy integration and other advanced topics, see the
 [docs](https://curl-cffi.readthedocs.io) for more details.
+
+### asyncio WebSockets
+
+```python
+import asyncio
+from curl_cffi.requests import AsyncSession
+
+async with AsyncSession() as s:
+    ws = await s.ws_connect("wss://echo.websocket.org")
+    await asyncio.gather(*[ws.send_str("Hello, World!") for _ in range(10)])
+    async for message in ws:
+        print(message)
+```
 
 ## Acknowledgement
 
 - Originally forked from [multippt/python_curl_cffi](https://github.com/multippt/python_curl_cffi), which is under the MIT license.
 - Headers/Cookies files are copied from [httpx](https://github.com/encode/httpx/blob/master/httpx/_models.py), which is under the BSD license.
 - Asyncio support is inspired by Tornado's curl http client.
-- The WebSocket API is inspired by [websocket_client](https://github.com/websocket-client/websocket-client).
+- The synchronous WebSocket API is inspired by [websocket_client](https://github.com/websocket-client/websocket-client).
+- The asynchronous WebSocket API is inspired by [aiohttp](https://github.com/aio-libs/aiohttp).
 
 
 ## Sponsor

--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -321,7 +321,7 @@ class Curl:
                 lib.curl_slist_free_all(self._proxy_headers)
             self._proxy_headers = ffi.NULL
 
-    def duphandle(self) -> "Curl":
+    def duphandle(self) -> Curl:
         """Wrapper for ``curl_easy_duphandle``.
 
         This is not a full copy of entire curl object in python. For example, headers

--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import struct
 import warnings
 from http.cookies import SimpleCookie
 from pathlib import Path
@@ -432,6 +433,23 @@ class Curl:
         ret = lib.curl_ws_send(self._curl, buffer, len(buffer), n_sent, 0, flags)
         self._check_error(ret, "WS_SEND")
         return n_sent[0]
+
+    def ws_close(self, code: int = 1000, message: bytes = b"") -> int:
+        """Close a websocket connection. Shorthand for :meth:`ws_send`
+        with close code and message. Note that to completely close the connection,
+        you must close the curl handle after this call with :meth:`close`.
+
+        Args:
+            code: close code.
+            message: close message.
+
+        Returns:
+            0 if no error.
+
+        Raises:
+            CurlError: if failed.
+        """
+        return self.ws_send(struct.pack("!H", code) + message)
 
 
 class CurlMime:

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "Headers",
     "Request",
     "Response",
+    "AsyncWebSocket",
     "WebSocket",
     "WebSocketError",
     "WsCloseCode",
@@ -38,7 +39,7 @@ from .headers import Headers, HeaderTypes
 from .impersonate import BrowserType, BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
 from .models import Request, Response
 from .session import AsyncSession, HttpMethod, ProxySpec, Session, ThreadType
-from .websockets import WebSocket, WebSocketError, WsCloseCode
+from .websockets import AsyncWebSocket, WebSocket, WebSocketError, WsCloseCode
 
 
 def request(

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -41,7 +41,14 @@ from .headers import Headers, HeaderTypes
 from .impersonate import BrowserType, BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
 from .models import Request, Response
 from .session import AsyncSession, HttpMethod, ProxySpec, Session, ThreadType
-from .websockets import AsyncWebSocket, WebSocket, WebSocketClosed, WebSocketError, WebSocketTimeout, WsCloseCode
+from .websockets import (
+    AsyncWebSocket,
+    WebSocket,
+    WebSocketClosed,
+    WebSocketError,
+    WebSocketTimeout,
+    WsCloseCode,
+)
 
 
 def request(

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
     "AsyncWebSocket",
     "WebSocket",
     "WebSocketError",
+    "WebSocketClosed",
+    "WebSocketTimeout",
     "WsCloseCode",
     "ExtraFingerprints",
     "CookieTypes",
@@ -39,7 +41,7 @@ from .headers import Headers, HeaderTypes
 from .impersonate import BrowserType, BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
 from .models import Request, Response
 from .session import AsyncSession, HttpMethod, ProxySpec, Session, ThreadType
-from .websockets import AsyncWebSocket, WebSocket, WebSocketError, WsCloseCode
+from .websockets import AsyncWebSocket, WebSocket, WebSocketClosed, WebSocketError, WebSocketTimeout, WsCloseCode
 
 
 def request(

--- a/curl_cffi/requests/cookies.py
+++ b/curl_cffi/requests/cookies.py
@@ -273,7 +273,9 @@ class Cookies(MutableMapping[str, str]):
         """
         ret = {}
         for cookie in self.jar:
-            if (domain is None or cookie.domain == domain) and (path is None or cookie.path == path):
+            if (domain is None or cookie.domain == domain) and (
+                path is None or cookie.path == path
+            ):
                 ret[cookie.name] = cookie.value
         return ret
 

--- a/curl_cffi/requests/options.py
+++ b/curl_cffi/requests/options.py
@@ -19,7 +19,7 @@ from typing import (
     Tuple,
     Union,
 )
-from urllib.parse import ParseResult, parse_qsl, quote, unquote, urlencode, urlparse
+from urllib.parse import ParseResult, parse_qsl, quote, unquote, urlencode, urljoin, urlparse
 
 from .. import CurlHttpVersion, CurlOpt, CurlSslVersion
 from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
@@ -305,6 +305,7 @@ def set_curl_options(
     url: str,
     *,
     params: Optional[Union[Dict, List, Tuple]] = None,
+    base_url: Optional[str] = None,
     data: Optional[Union[Dict[str, str], List[Tuple], str, BytesIO, bytes]] = None,
     json: Optional[dict] = None,
     headers: Optional[HeaderTypes] = None,
@@ -354,6 +355,8 @@ def set_curl_options(
     # url
     if params:
         url = update_url_params(url, params)
+    if base_url:
+        url = urljoin(base_url, url)
     if quote:
         url = quote_path_and_params(url, quote_str=quote)
     if quote is not False:

--- a/curl_cffi/requests/options.py
+++ b/curl_cffi/requests/options.py
@@ -337,7 +337,7 @@ def set_curl_options(
     multipart: Optional[CurlMime] = None,
     queue_class: Any = None,
     event_class: Any = None,
-    curl_options: Optional[dict] = None,
+    curl_options: Optional[Dict[CurlOpt, str]] = None,
 ):
     c = curl
 
@@ -564,7 +564,7 @@ def set_curl_options(
     # impersonate
     if impersonate:
         impersonate = normalize_browser_type(impersonate)
-        ret = c.impersonate(impersonate, default_headers=default_headers)
+        ret = c.impersonate(impersonate, default_headers=default_headers)  # type: ignore
         if ret != 0:
             raise ImpersonateError(f"Impersonating {impersonate} is not supported")
 

--- a/curl_cffi/requests/options.py
+++ b/curl_cffi/requests/options.py
@@ -605,8 +605,8 @@ def set_curl_options(
 
     # set extra curl options, must come after impersonate, because it will alter some options
     if curl_options:
-        for k, v in curl_options.items():
-            c.setopt(k, v)
+        for option, setting in curl_options.items():
+            c.setopt(option, setting)
 
     buffer = None
     q = None

--- a/curl_cffi/requests/options.py
+++ b/curl_cffi/requests/options.py
@@ -1,0 +1,639 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import queue
+import warnings
+from collections import Counter
+from io import BytesIO
+from json import dumps
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    cast,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
+from urllib.parse import ParseResult, parse_qsl, quote, unquote, urlencode, urlparse
+
+from .. import CurlHttpVersion, CurlOpt, CurlSslVersion
+from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
+from .cookies import Cookies
+from .exceptions import ImpersonateError, InvalidURL
+from .headers import Headers
+from .impersonate import (
+    TLS_CIPHER_NAME_MAP,
+    TLS_EC_CURVES_MAP,
+    TLS_VERSION_MAP,
+    ExtraFingerprints,
+    normalize_browser_type,
+    toggle_extension,
+)
+from .models import Request
+
+if TYPE_CHECKING:
+    from ..curl import Curl
+    from .cookies import CookieTypes
+    from .headers import HeaderTypes
+    from .impersonate import BrowserTypeLiteral, ExtraFpDict
+    from .session import ProxySpec
+
+
+HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "PATCH", "QUERY"]
+
+SAFE_CHARS = set("!#$%&'()*+,/:;=?@[]~")
+
+not_set = object()
+
+
+def is_absolute_url(url: str) -> bool:
+    """Check if the provided url is an absolute url"""
+    parsed_url = urlparse(url)
+    return bool(parsed_url.scheme and parsed_url.hostname)
+
+
+def quote_path_and_params(url: str, quote_str: str = ""):
+    safe = "".join(SAFE_CHARS - set(quote_str))
+    parsed_url = urlparse(url)
+    parsed_get_args = parse_qsl(parsed_url.query, keep_blank_values=True)
+    encoded_get_args = urlencode(parsed_get_args, doseq=True, safe=safe)
+    return ParseResult(
+        parsed_url.scheme,
+        parsed_url.netloc,
+        quote(parsed_url.path, safe=safe),
+        parsed_url.params,
+        encoded_get_args,
+        parsed_url.fragment,
+    ).geturl()
+
+
+def update_url_params(url: str, params: Union[Dict, List, Tuple]) -> str:
+    """Add URL query params to provided URL being aware of existing.
+
+    Parameters:
+        url: string of target URL
+        params: dict containing requested params to be added
+
+    Returns:
+        string with updated URL
+
+    >> url = 'http://stackoverflow.com/test?answers=true'
+    >> new_params = {'answers': False, 'data': ['some','values']}
+    >> _update_url_params(url, new_params)
+    'http://stackoverflow.com/test?data=some&data=values&answers=false'
+    """
+    # Unquoting and parse
+    url = unquote(url)
+    parsed_url = urlparse(url)
+
+    # Extracting URL arguments from parsed URL, NOTE the result is a list, not dict
+    parsed_get_args = parse_qsl(parsed_url.query, keep_blank_values=True)
+
+    # Merging URL arguments dict with new params
+    old_args_counter = Counter(x[0] for x in parsed_get_args)
+    if isinstance(params, dict):
+        params = list(params.items())
+    new_args_counter = Counter(x[0] for x in params)
+    for key, value in params:
+        # Bool and Dict values should be converted to json-friendly values
+        if isinstance(value, (bool, dict)):
+            value = dumps(value)
+        # 1 to 1 mapping, we have to search and update it.
+        if old_args_counter.get(key) == 1 and new_args_counter.get(key) == 1:
+            parsed_get_args = [(x if x[0] != key else (key, value)) for x in parsed_get_args]
+        else:
+            parsed_get_args.append((key, value))
+
+    # Converting URL argument to proper query string
+    encoded_get_args = urlencode(parsed_get_args, doseq=True)
+
+    # Creating new parsed result object based on provided with new
+    # URL arguments. Same thing happens inside of urlparse.
+    new_url = ParseResult(
+        parsed_url.scheme,
+        parsed_url.netloc,
+        parsed_url.path,
+        parsed_url.params,
+        encoded_get_args,
+        parsed_url.fragment,
+    ).geturl()
+
+    return new_url
+
+
+# Adapted from: https://github.com/psf/requests/blob/1ae6fc3137a11e11565ed22436aa1e77277ac98c/src%2Frequests%2Futils.py#L633-L682
+# License: Apache 2.0
+
+# The unreserved URI characters (RFC 3986)
+UNRESERVED_SET = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789-._~")
+
+
+def unquote_unreserved(uri: str) -> str:
+    """Un-escape any percent-escape sequences in a URI that are unreserved
+    characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
+    """
+    parts = uri.split("%")
+    for i in range(1, len(parts)):
+        h = parts[i][0:2]
+        if len(h) == 2 and h.isalnum():
+            try:
+                c = chr(int(h, 16))
+            except ValueError:
+                raise InvalidURL(f"Invalid percent-escape sequence: '{h}'")
+
+            if c in UNRESERVED_SET:
+                parts[i] = c + parts[i][2:]
+            else:
+                parts[i] = f"%{parts[i]}"
+        else:
+            parts[i] = f"%{parts[i]}"
+    return "".join(parts)
+
+
+def requote_uri(uri: str) -> str:
+    """Re-quote the given URI.
+
+    This function passes the given URI through an unquote/quote cycle to
+    ensure that it is fully and consistently quoted.
+    """
+    safe_with_percent = "!#$%&'()*+,/:;=?@[]~|"
+    safe_without_percent = "!#$&'()*+,/:;=?@[]~|"
+    try:
+        # Unquote only the unreserved characters
+        # Then quote only illegal characters (do not quote reserved,
+        # unreserved, or '%')
+        return quote(unquote_unreserved(uri), safe=safe_with_percent)
+    except InvalidURL:
+        # We couldn't unquote the given URI, so let's try quoting it, but
+        # there may be unquoted '%'s in the URI. We need to make sure they're
+        # properly quoted so they do not cause issues elsewhere.
+        return quote(uri, safe=safe_without_percent)
+
+
+# TODO: should we move this function to headers.py?
+def update_header_line(header_lines: List[str], key: str, value: str, replace: bool = False):
+    """Update header line list by key value pair."""
+    found = False
+    for idx, line in enumerate(header_lines):
+        if line.lower().startswith(key.lower() + ":"):
+            found = True
+            if replace:
+                header_lines[idx] = f"{key}: {value}"
+            break
+    if not found:
+        header_lines.append(f"{key}: {value}")
+
+
+def peek_queue(q: queue.Queue, default=None):
+    try:
+        return q.queue[0]
+    except IndexError:
+        return default
+
+
+def peek_aio_queue(q: asyncio.Queue, default=None):
+    try:
+        return q._queue[0]  # type: ignore
+    except IndexError:
+        return default
+
+
+def toggle_extensions_by_ids(curl: Curl, extension_ids):
+    # TODO find a better representation, rather than magic numbers
+    default_enabled = {0, 51, 13, 43, 65281, 23, 10, 45, 35, 11, 16}
+
+    to_enable_ids = extension_ids - default_enabled
+    for ext_id in to_enable_ids:
+        toggle_extension(curl, ext_id, enable=True)
+
+    # print("to_enable: ", to_enable_ids)
+
+    to_disable_ids = default_enabled - extension_ids
+    for ext_id in to_disable_ids:
+        toggle_extension(curl, ext_id, enable=False)
+
+    # print("to_disable: ", to_disable_ids)
+
+
+def set_ja3_options(curl: Curl, ja3: str, permute: bool = False):
+    """
+    Detailed explanation: https://engineering.salesforce.com/tls-fingerprinting-with-ja3-and-ja3s-247362855967/
+    """
+    tls_version, ciphers, extensions, curves, curve_formats = ja3.split(",")
+
+    curl_tls_version = TLS_VERSION_MAP[int(tls_version)]
+    curl.setopt(CurlOpt.SSLVERSION, curl_tls_version | CurlSslVersion.MAX_DEFAULT)
+    assert curl_tls_version == CurlSslVersion.TLSv1_2, "Only TLS v1.2 works for now."
+
+    cipher_names = []
+    for cipher in ciphers.split("-"):
+        cipher_id = int(cipher)
+        cipher_name = TLS_CIPHER_NAME_MAP[cipher_id]
+        cipher_names.append(cipher_name)
+
+    curl.setopt(CurlOpt.SSL_CIPHER_LIST, ":".join(cipher_names))
+
+    if extensions.endswith("-21"):
+        extensions = extensions[:-3]
+        warnings.warn(
+            "Padding(21) extension found in ja3 string, whether to add it should "
+            "be managed by the SSL engine. The TLS client hello packet may contain "
+            "or not contain this extension, any of which should be correct.",
+            stacklevel=1,
+        )
+    extension_ids = set(int(e) for e in extensions.split("-"))
+    toggle_extensions_by_ids(curl, extension_ids)
+
+    if not permute:
+        curl.setopt(CurlOpt.TLS_EXTENSION_ORDER, extensions)
+
+    curve_names = []
+    for curve in curves.split("-"):
+        curve_id = int(curve)
+        curve_name = TLS_EC_CURVES_MAP[curve_id]
+        curve_names.append(curve_name)
+
+    curl.setopt(CurlOpt.SSL_EC_CURVES, ":".join(curve_names))
+
+    assert int(curve_formats) == 0, "Only curve_formats == 0 is supported."
+
+
+def set_akamai_options(curl: Curl, akamai: str):
+    """
+    Detailed explanation: https://www.blackhat.com/docs/eu-17/materials/eu-17-Shuster-Passive-Fingerprinting-Of-HTTP2-Clients-wp.pdf
+    """
+    settings, window_update, streams, header_order = akamai.split("|")
+
+    # For compatiblity with tls.peet.ws
+    settings = settings.replace(",", ";")
+
+    curl.setopt(CurlOpt.HTTP_VERSION, CurlHttpVersion.V2_0)
+
+    curl.setopt(CurlOpt.HTTP2_SETTINGS, settings)
+    curl.setopt(CurlOpt.HTTP2_WINDOW_UPDATE, int(window_update))
+
+    if streams != "0":
+        curl.setopt(CurlOpt.HTTP2_STREAMS, streams)
+
+    # m,a,s,p -> masp
+    # curl-impersonate only accepts masp format, without commas.
+    curl.setopt(CurlOpt.HTTP2_PSEUDO_HEADERS_ORDER, header_order.replace(",", ""))
+
+
+def set_extra_fp(curl: Curl, fp: ExtraFingerprints):
+    if fp.tls_signature_algorithms:
+        curl.setopt(CurlOpt.SSL_SIG_HASH_ALGS, ",".join(fp.tls_signature_algorithms))
+
+    curl.setopt(CurlOpt.SSLVERSION, fp.tls_min_version | CurlSslVersion.MAX_DEFAULT)
+    curl.setopt(CurlOpt.TLS_GREASE, int(fp.tls_grease))
+    curl.setopt(CurlOpt.SSL_PERMUTE_EXTENSIONS, int(fp.tls_permute_extensions))
+    curl.setopt(CurlOpt.SSL_CERT_COMPRESSION, fp.tls_cert_compression)
+    curl.setopt(CurlOpt.STREAM_WEIGHT, fp.http2_stream_weight)
+    curl.setopt(CurlOpt.STREAM_EXCLUSIVE, fp.http2_stream_exclusive)
+
+def set_curl_options(
+    curl: Curl,
+    method: HttpMethod,
+    url: str,
+    *,
+    params: Optional[Union[Dict, List, Tuple]] = None,
+    data: Optional[Union[Dict[str, str], List[Tuple], str, BytesIO, bytes]] = None,
+    json: Optional[dict] = None,
+    headers: Optional[HeaderTypes] = None,
+    session_cookies: Optional[Cookies] = None,
+    cookies: Optional[CookieTypes] = None,
+    files: Optional[Dict] = None,
+    auth: Optional[Tuple[str, str]] = None,
+    timeout: Optional[Union[float, Tuple[float, float], object]] = not_set,
+    allow_redirects: bool = True,
+    max_redirects: Optional[int] = 30,
+    proxies: Optional[ProxySpec] = None,
+    proxy: Optional[str] = None,
+    proxy_auth: Optional[Tuple[str, str]] = None,
+    verify: Optional[Union[bool, str]] = None,
+    session_verify: Optional[Union[bool, str]] = None,
+    referer: Optional[str] = None,
+    accept_encoding: Optional[str] = "gzip, deflate, br, zstd",
+    content_callback: Optional[Callable] = None,
+    impersonate: Optional[BrowserTypeLiteral] = None,
+    ja3: Optional[str] = None,
+    akamai: Optional[str] = None,
+    extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
+    default_headers: bool = True,
+    quote: Union[str, Literal[False]] = "",
+    http_version: Optional[CurlHttpVersion] = None,
+    interface: Optional[str] = None,
+    cert: Optional[Union[str, Tuple[str, str]]] = None,
+    stream: bool = False,
+    max_recv_speed: int = 0,
+    multipart: Optional[CurlMime] = None,
+    queue_class: Any = None,
+    event_class: Any = None,
+    curl_options: Optional[dict] = None,
+):
+    c = curl
+
+    method = method.upper()  # type: ignore
+
+    # method
+    if method == "POST":
+        c.setopt(CurlOpt.POST, 1)
+    elif method != "GET":
+        c.setopt(CurlOpt.CUSTOMREQUEST, method.encode())
+    if method == "HEAD":
+        c.setopt(CurlOpt.NOBODY, 1)
+
+    # url
+    if params:
+        url = update_url_params(url, params)
+    if quote:
+        url = quote_path_and_params(url, quote_str=quote)
+    if quote is not False:
+        url = requote_uri(url)
+    c.setopt(CurlOpt.URL, url.encode())
+
+    # data/body/json
+    if isinstance(data, (dict, list, tuple)):
+        body = urlencode(data).encode()
+    elif isinstance(data, str):
+        body = data.encode()
+    elif isinstance(data, BytesIO):
+        body = data.read()
+    elif isinstance(data, bytes):
+        body = data
+    elif data is None:
+        body = b""
+    else:
+        raise TypeError("data must be dict/list/tuple, str, BytesIO or bytes")
+    if json is not None:
+        body = dumps(json, separators=(",", ":")).encode()
+
+    # Tell libcurl to be aware of bodies and related headers when,
+    # 1. POST/PUT/PATCH, even if the body is empty, it's up to curl to decide what to do;
+    # 2. GET/DELETE with body, although it's against the RFC, some applications.
+    #   e.g. Elasticsearch, use this.
+    if body or method in ("POST", "PUT", "PATCH"):
+        c.setopt(CurlOpt.POSTFIELDS, body)
+        # necessary if body contains '\0'
+        c.setopt(CurlOpt.POSTFIELDSIZE, len(body))
+        if method == "GET":
+            c.setopt(CurlOpt.CUSTOMREQUEST, method)
+
+    # headers
+    h = Headers(headers)
+
+    # remove Host header if it's unnecessary, otherwise curl may get confused.
+    # Host header will be automatically added by curl if it's not present.
+    # https://github.com/lexiforest/curl_cffi/issues/119
+    host_header = h.get("Host")
+    if host_header is not None:
+        u = urlparse(url)
+        if host_header == u.netloc or host_header == u.hostname:
+            h.pop("Host", None)
+
+    # Make curl always include empty headers.
+    # See: https://stackoverflow.com/a/32911474/1061155
+    header_lines = []
+    for k, v in h.multi_items():
+        header_lines.append(f"{k}: {v}" if v else f"{k};")
+
+    # Add content-type if missing
+    if json is not None:
+        update_header_line(header_lines, "Content-Type", "application/json", replace=True)
+    if isinstance(data, dict) and method != "POST":
+        update_header_line(header_lines, "Content-Type", "application/x-www-form-urlencoded")
+    if isinstance(data, (str, bytes)):
+        update_header_line(header_lines, "Content-Type", "application/octet-stream")
+
+    # Never send `Expect` header.
+    update_header_line(header_lines, "Expect", "", replace=True)
+
+    c.setopt(CurlOpt.HTTPHEADER, [h.encode() for h in header_lines])
+
+    req = Request(url, h, method)
+
+    # cookies
+    c.setopt(CurlOpt.COOKIEFILE, b"")  # always enable the curl cookie engine first
+    c.setopt(CurlOpt.COOKIELIST, "ALL")  # remove all the old cookies first.
+
+    if session_cookies:
+        for morsel in session_cookies.get_cookies_for_curl(req):
+            # print("Setting", morsel.to_curl_format())
+            curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
+    if cookies:
+        temp_cookies = Cookies(cookies)
+        for morsel in temp_cookies.get_cookies_for_curl(req):
+            curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
+
+    # files
+    if files:
+        raise NotImplementedError(
+            "files is not supported, use `multipart`. See examples here: "
+            "https://github.com/lexiforest/curl_cffi/blob/main/examples/upload.py"
+        )
+
+    # multipart
+    if multipart:
+        # multipart will overrides postfields
+        for k, v in cast(dict, data or {}).items():
+            multipart.addpart(name=k, data=v.encode() if isinstance(v, str) else v)
+        c.setopt(CurlOpt.MIMEPOST, multipart._form)
+
+    # auth
+    if auth:
+        username, password = auth
+        c.setopt(CurlOpt.USERNAME, username.encode())  # pyright: ignore [reportPossiblyUnboundVariable=none]
+        c.setopt(CurlOpt.PASSWORD, password.encode())  # pyright: ignore [reportPossiblyUnboundVariable=none]
+
+    # timeout
+    if timeout in (None, not_set):
+        timeout = 0  # indefinitely
+
+    if isinstance(timeout, tuple):
+        connect_timeout, read_timeout = timeout
+        all_timeout = connect_timeout + read_timeout
+        c.setopt(CurlOpt.CONNECTTIMEOUT_MS, int(connect_timeout * 1000))
+        if not stream:
+            c.setopt(CurlOpt.TIMEOUT_MS, int(all_timeout * 1000))
+        else:
+            # trick from: https://github.com/lexiforest/curl_cffi/issues/156
+            c.setopt(CurlOpt.LOW_SPEED_LIMIT, 1)
+            c.setopt(CurlOpt.LOW_SPEED_TIME, math.ceil(all_timeout))
+
+    elif isinstance(timeout, (int, float)):
+        if not stream:
+            c.setopt(CurlOpt.TIMEOUT_MS, int(timeout * 1000))
+        else:
+            c.setopt(CurlOpt.CONNECTTIMEOUT_MS, int(timeout * 1000))
+            c.setopt(CurlOpt.LOW_SPEED_LIMIT, 1)
+            c.setopt(CurlOpt.LOW_SPEED_TIME, math.ceil(timeout))
+
+    # allow_redirects
+    c.setopt(
+        CurlOpt.FOLLOWLOCATION,
+        int(allow_redirects),
+    )
+
+    # max_redirects
+    c.setopt(
+        CurlOpt.MAXREDIRS,
+        max_redirects,
+    )
+
+    # proxies
+    if proxy and proxies:
+        raise TypeError("Cannot specify both 'proxy' and 'proxies'")
+    if proxy:
+        proxies = {"all": proxy}
+
+    if proxies:
+        parts = urlparse(url)
+        proxy = cast(Optional[str], proxies.get(parts.scheme, proxies.get("all")))
+        if parts.hostname:
+            proxy = (
+                cast(
+                    Optional[str],
+                    proxies.get(
+                        f"{parts.scheme}://{parts.hostname}",
+                        proxies.get(f"all://{parts.hostname}"),
+                    ),
+                )
+                or proxy
+            )
+
+        if proxy is not None:
+            c.setopt(CurlOpt.PROXY, proxy)
+
+            if parts.scheme == "https":
+                if proxy.startswith("https://"):
+                    warnings.warn(
+                        "Make sure you are using https over https proxy, otherwise, "
+                        "the proxy prefix should be 'http://' not 'https://', "
+                        "see: https://github.com/lexiforest/curl_cffi/issues/6",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
+                # For https site with http tunnel proxy, tell curl to enable tunneling
+                if not proxy.startswith("socks"):
+                    c.setopt(CurlOpt.HTTPPROXYTUNNEL, 1)
+
+            # proxy_auth
+            if proxy_auth:
+                username, password = proxy_auth
+                c.setopt(CurlOpt.PROXYUSERNAME, username.encode())
+                c.setopt(CurlOpt.PROXYPASSWORD, password.encode())
+
+    # verify
+    if verify is False or not session_verify and verify is None:
+        c.setopt(CurlOpt.SSL_VERIFYPEER, 0)
+        c.setopt(CurlOpt.SSL_VERIFYHOST, 0)
+
+    # cert for this single request
+    if isinstance(verify, str):
+        c.setopt(CurlOpt.CAINFO, verify)
+
+    # cert for the session
+    if verify in (None, True) and isinstance(session_verify, str):
+        c.setopt(CurlOpt.CAINFO, session_verify)
+
+    # referer
+    if referer:
+        c.setopt(CurlOpt.REFERER, referer.encode())
+
+    # accept_encoding
+    if accept_encoding is not None:
+        c.setopt(CurlOpt.ACCEPT_ENCODING, accept_encoding.encode())
+
+    # cert
+    if cert:
+        if isinstance(cert, str):
+            c.setopt(CurlOpt.SSLCERT, cert)
+        else:
+            cert, key = cert
+            c.setopt(CurlOpt.SSLCERT, cert)
+            c.setopt(CurlOpt.SSLKEY, key)
+
+    # impersonate
+    if impersonate:
+        impersonate = normalize_browser_type(impersonate)
+        ret = c.impersonate(impersonate, default_headers=default_headers)
+        if ret != 0:
+            raise ImpersonateError(f"Impersonating {impersonate} is not supported")
+
+    # ja3 string
+    if ja3:
+        if impersonate:
+            warnings.warn("JA3 was altered after browser version was set.", stacklevel=1)
+        permute = False
+        if isinstance(extra_fp, ExtraFingerprints) and extra_fp.tls_permute_extensions:
+            permute = True
+        if isinstance(extra_fp, dict) and extra_fp.get("tls_permute_extensions"):
+            permute = True
+        set_ja3_options(c, ja3, permute=permute)
+
+    # akamai string
+    if akamai:
+        if impersonate:
+            warnings.warn("Akamai was altered after browser version was set.", stacklevel=1)
+        set_akamai_options(c, akamai)
+
+    # extra_fp options
+    if extra_fp:
+        if isinstance(extra_fp, dict):
+            extra_fp = ExtraFingerprints(**extra_fp)
+        if impersonate:
+            warnings.warn(
+                "Extra fingerprints was altered after browser version was set.",
+                stacklevel=1,
+            )
+        set_extra_fp(c, extra_fp)
+
+    # http_version, after impersonate, which will change this to http2
+    if http_version:
+        c.setopt(CurlOpt.HTTP_VERSION, http_version)
+
+    # set extra curl options, must come after impersonate, because it will alter some options
+    if curl_options:
+        for k, v in curl_options.items():
+            c.setopt(k, v)
+
+    buffer = None
+    q = None
+    header_recved = None
+    quit_now = None
+    if stream:
+        q = queue_class()
+        header_recved = event_class()
+        quit_now = event_class()
+
+        def qput(chunk):
+            if not header_recved.is_set():
+                header_recved.set()
+            if quit_now.is_set():
+                return CURL_WRITEFUNC_ERROR
+            q.put_nowait(chunk)
+            return len(chunk)
+
+        c.setopt(CurlOpt.WRITEFUNCTION, qput)
+    elif content_callback is not None:
+        c.setopt(CurlOpt.WRITEFUNCTION, content_callback)
+    else:
+        buffer = BytesIO()
+        c.setopt(CurlOpt.WRITEDATA, buffer)
+    header_buffer = BytesIO()
+    c.setopt(CurlOpt.HEADERDATA, header_buffer)
+
+    # interface
+    if interface:
+        c.setopt(CurlOpt.INTERFACE, interface.encode())
+
+    # max_recv_speed
+    # do not check, since 0 is a valid value to disable it
+    c.setopt(CurlOpt.MAX_RECV_SPEED_LARGE, max_recv_speed)
+
+    return req, buffer, header_buffer, q, header_recved, quit_now

--- a/curl_cffi/requests/options.py
+++ b/curl_cffi/requests/options.py
@@ -84,7 +84,7 @@ def update_url_params(url: str, params: Union[Dict, List, Tuple]) -> str:
 
     >> url = 'http://stackoverflow.com/test?answers=true'
     >> new_params = {'answers': False, 'data': ['some','values']}
-    >> _update_url_params(url, new_params)
+    >> update_url_params(url, new_params)
     'http://stackoverflow.com/test?data=some&data=values&answers=false'
     """
     # Unquoting and parse
@@ -130,7 +130,9 @@ def update_url_params(url: str, params: Union[Dict, List, Tuple]) -> str:
 # License: Apache 2.0
 
 # The unreserved URI characters (RFC 3986)
-UNRESERVED_SET = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789-._~")
+UNRESERVED_SET = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789-._~"
+)
 
 
 def unquote_unreserved(uri: str) -> str:
@@ -295,6 +297,7 @@ def set_extra_fp(curl: Curl, fp: ExtraFingerprints):
     curl.setopt(CurlOpt.SSL_CERT_COMPRESSION, fp.tls_cert_compression)
     curl.setopt(CurlOpt.STREAM_WEIGHT, fp.http2_stream_weight)
     curl.setopt(CurlOpt.STREAM_EXCLUSIVE, fp.http2_stream_exclusive)
+
 
 def set_curl_options(
     curl: Curl,

--- a/curl_cffi/requests/options.py
+++ b/curl_cffi/requests/options.py
@@ -7,18 +7,7 @@ import warnings
 from collections import Counter
 from io import BytesIO
 from json import dumps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    cast,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple, Union, cast
 from urllib.parse import ParseResult, parse_qsl, quote, unquote, urlencode, urljoin, urlparse
 
 from .. import CurlHttpVersion, CurlOpt, CurlSslVersion

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -20,7 +20,7 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import ParseResult, parse_qsl, quote, urlencode, urljoin, urlparse
+from urllib.parse import ParseResult, parse_qsl, quote, urlencode, urlparse
 
 from typing_extensions import Unpack
 
@@ -247,8 +247,6 @@ class BaseSession:
         """Merge curl options from session and request."""
         if self.params:
             url = update_url_params(url, self.params)
-        if self.base_url:
-            url = urljoin(self.base_url, url)
 
         _headers = Headers(self.headers)
         _headers.update(headers)
@@ -261,6 +259,7 @@ class BaseSession:
             method=method,
             url=url,
             params=params,
+            base_url=self.base_url,
             data=data,
             json=json,
             headers=_headers,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -6,7 +6,6 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from functools import partialmethod
 from io import BytesIO
-from json import dumps
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -1,9 +1,7 @@
 import asyncio
-import math
 import queue
 import threading
 import warnings
-from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
 from functools import partialmethod
@@ -23,28 +21,23 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import ParseResult, parse_qsl, quote, unquote, urlencode, urljoin, urlparse
+from urllib.parse import ParseResult, parse_qsl, quote, urlencode, urljoin, urlparse
 
 from typing_extensions import Unpack
 
-from .. import AsyncCurl, Curl, CurlError, CurlHttpVersion, CurlInfo, CurlOpt, CurlSslVersion
-from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
+from .. import AsyncCurl, Curl, CurlError, CurlHttpVersion, CurlInfo, CurlOpt
+from ..curl import CurlMime
 from .cookies import Cookies, CookieTypes, CurlMorsel
-from .exceptions import InvalidURL, ImpersonateError, RequestException, SessionClosed, code2error
+from .exceptions import RequestException, SessionClosed, code2error
 from .headers import Headers, HeaderTypes
-from .impersonate import BrowserType  # noqa: F401
 from .impersonate import (
-    TLS_CIPHER_NAME_MAP,
-    TLS_EC_CURVES_MAP,
-    TLS_VERSION_MAP,
     BrowserTypeLiteral,
     ExtraFingerprints,
     ExtraFpDict,
-    normalize_browser_type,
-    toggle_extension,
 )
-from .models import Request, Response
-from .websockets import ON_CLOSE_T, ON_ERROR_T, ON_MESSAGE_T, ON_OPEN_T, WebSocket
+from .models import Response
+from .options import set_curl_options, update_url_params
+from .websockets import AsyncWebSocket
 
 with suppress(ImportError):
     import gevent
@@ -119,125 +112,6 @@ def _quote_path_and_params(url: str, quote_str: str = ""):
         encoded_get_args,
         parsed_url.fragment,
     ).geturl()
-
-
-def _update_url_params(url: str, params: Union[Dict, List, Tuple]) -> str:
-    """Add URL query params to provided URL being aware of existing.
-
-    Parameters:
-        url: string of target URL
-        params: dict containing requested params to be added
-
-    Returns:
-        string with updated URL
-
-    >> url = 'http://stackoverflow.com/test?answers=true'
-    >> new_params = {'answers': False, 'data': ['some','values']}
-    >> _update_url_params(url, new_params)
-    'http://stackoverflow.com/test?data=some&data=values&answers=false'
-    """
-    # Unquoting and parse
-    url = unquote(url)
-    parsed_url = urlparse(url)
-
-    # Extracting URL arguments from parsed URL, NOTE the result is a list, not dict
-    parsed_get_args = parse_qsl(parsed_url.query, keep_blank_values=True)
-
-    # Merging URL arguments dict with new params
-    old_args_counter = Counter(x[0] for x in parsed_get_args)
-    if isinstance(params, dict):
-        params = list(params.items())
-    new_args_counter = Counter(x[0] for x in params)
-    for key, value in params:
-        # Bool and Dict values should be converted to json-friendly values
-        if isinstance(value, (bool, dict)):
-            value = dumps(value)
-        # 1 to 1 mapping, we have to search and update it.
-        if old_args_counter.get(key) == 1 and new_args_counter.get(key) == 1:
-            parsed_get_args = [(x if x[0] != key else (key, value)) for x in parsed_get_args]
-        else:
-            parsed_get_args.append((key, value))
-
-    # Converting URL argument to proper query string
-    encoded_get_args = urlencode(parsed_get_args, doseq=True)
-
-    # Creating new parsed result object based on provided with new
-    # URL arguments. Same thing happens inside of urlparse.
-    new_url = ParseResult(
-        parsed_url.scheme,
-        parsed_url.netloc,
-        parsed_url.path,
-        parsed_url.params,
-        encoded_get_args,
-        parsed_url.fragment,
-    ).geturl()
-
-    return new_url
-
-
-# Adapted from: https://github.com/psf/requests/blob/1ae6fc3137a11e11565ed22436aa1e77277ac98c/src%2Frequests%2Futils.py#L633-L682
-# License: Apache 2.0
-
-# The unreserved URI characters (RFC 3986)
-UNRESERVED_SET = frozenset(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789-._~"
-)
-
-
-def unquote_unreserved(uri: str) -> str:
-    """Un-escape any percent-escape sequences in a URI that are unreserved
-    characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
-    """
-    parts = uri.split("%")
-    for i in range(1, len(parts)):
-        h = parts[i][0:2]
-        if len(h) == 2 and h.isalnum():
-            try:
-                c = chr(int(h, 16))
-            except ValueError:
-                raise InvalidURL(f"Invalid percent-escape sequence: '{h}'")
-
-            if c in UNRESERVED_SET:
-                parts[i] = c + parts[i][2:]
-            else:
-                parts[i] = f"%{parts[i]}"
-        else:
-            parts[i] = f"%{parts[i]}"
-    return "".join(parts)
-
-
-def requote_uri(uri: str) -> str:
-    """Re-quote the given URI.
-
-    This function passes the given URI through an unquote/quote cycle to
-    ensure that it is fully and consistently quoted.
-    """
-    safe_with_percent = "!#$%&'()*+,/:;=?@[]~|"
-    safe_without_percent = "!#$&'()*+,/:;=?@[]~|"
-    try:
-        # Unquote only the unreserved characters
-        # Then quote only illegal characters (do not quote reserved,
-        # unreserved, or '%')
-        return quote(unquote_unreserved(uri), safe=safe_with_percent)
-    except InvalidURL:
-        # We couldn't unquote the given URI, so let's try quoting it, but
-        # there may be unquoted '%'s in the URI. We need to make sure they're
-        # properly quoted so they do not cause issues elsewhere.
-        return quote(uri, safe=safe_without_percent)
-
-
-# TODO: should we move this function to headers.py?
-def _update_header_line(header_lines: List[str], key: str, value: str, replace: bool = False):
-    """Update header line list by key value pair."""
-    found = False
-    for idx, line in enumerate(header_lines):
-        if line.lower().startswith(key.lower() + ":"):
-            found = True
-            if replace:
-                header_lines[idx] = f"{key}: {value}"
-            break
-    if not found:
-        header_lines.append(f"{key}: {value}")
 
 
 def _peek_queue(q: queue.Queue, default=None):
@@ -334,97 +208,7 @@ class BaseSession:
 
         self._closed = False
 
-    def _toggle_extensions_by_ids(self, curl, extension_ids):
-        # TODO find a better representation, rather than magic numbers
-        default_enabled = {0, 51, 13, 43, 65281, 23, 10, 45, 35, 11, 16}
-
-        to_enable_ids = extension_ids - default_enabled
-        for ext_id in to_enable_ids:
-            toggle_extension(curl, ext_id, enable=True)
-
-        # print("to_enable: ", to_enable_ids)
-
-        to_disable_ids = default_enabled - extension_ids
-        for ext_id in to_disable_ids:
-            toggle_extension(curl, ext_id, enable=False)
-
-        # print("to_disable: ", to_disable_ids)
-
-    def _set_ja3_options(self, curl, ja3: str, permute: bool = False):
-        """
-        Detailed explanation: https://engineering.salesforce.com/tls-fingerprinting-with-ja3-and-ja3s-247362855967/
-        """
-        tls_version, ciphers, extensions, curves, curve_formats = ja3.split(",")
-
-        curl_tls_version = TLS_VERSION_MAP[int(tls_version)]
-        curl.setopt(CurlOpt.SSLVERSION, curl_tls_version | CurlSslVersion.MAX_DEFAULT)
-        assert curl_tls_version == CurlSslVersion.TLSv1_2, "Only TLS v1.2 works for now."
-
-        cipher_names = []
-        for cipher in ciphers.split("-"):
-            cipher_id = int(cipher)
-            cipher_name = TLS_CIPHER_NAME_MAP[cipher_id]
-            cipher_names.append(cipher_name)
-
-        curl.setopt(CurlOpt.SSL_CIPHER_LIST, ":".join(cipher_names))
-
-        if extensions.endswith("-21"):
-            extensions = extensions[:-3]
-            warnings.warn(
-                "Padding(21) extension found in ja3 string, whether to add it should "
-                "be managed by the SSL engine. The TLS client hello packet may contain "
-                "or not contain this extension, any of which should be correct.",
-                stacklevel=1,
-            )
-        extension_ids = set(int(e) for e in extensions.split("-"))
-        self._toggle_extensions_by_ids(curl, extension_ids)
-
-        if not permute:
-            curl.setopt(CurlOpt.TLS_EXTENSION_ORDER, extensions)
-
-        curve_names = []
-        for curve in curves.split("-"):
-            curve_id = int(curve)
-            curve_name = TLS_EC_CURVES_MAP[curve_id]
-            curve_names.append(curve_name)
-
-        curl.setopt(CurlOpt.SSL_EC_CURVES, ":".join(curve_names))
-
-        assert int(curve_formats) == 0, "Only curve_formats == 0 is supported."
-
-    def _set_akamai_options(self, curl, akamai: str):
-        """
-        Detailed explanation: https://www.blackhat.com/docs/eu-17/materials/eu-17-Shuster-Passive-Fingerprinting-Of-HTTP2-Clients-wp.pdf
-        """
-        settings, window_update, streams, header_order = akamai.split("|")
-
-        # For compatiblity with tls.peet.ws
-        settings = settings.replace(",", ";")
-
-        curl.setopt(CurlOpt.HTTP_VERSION, CurlHttpVersion.V2_0)
-
-        curl.setopt(CurlOpt.HTTP2_SETTINGS, settings)
-        curl.setopt(CurlOpt.HTTP2_WINDOW_UPDATE, int(window_update))
-
-        if streams != "0":
-            curl.setopt(CurlOpt.HTTP2_STREAMS, streams)
-
-        # m,a,s,p -> masp
-        # curl-impersonate only accepts masp format, without commas.
-        curl.setopt(CurlOpt.HTTP2_PSEUDO_HEADERS_ORDER, header_order.replace(",", ""))
-
-    def _set_extra_fp(self, curl, fp: ExtraFingerprints):
-        if fp.tls_signature_algorithms:
-            curl.setopt(CurlOpt.SSL_SIG_HASH_ALGS, ",".join(fp.tls_signature_algorithms))
-
-        curl.setopt(CurlOpt.SSLVERSION, fp.tls_min_version | CurlSslVersion.MAX_DEFAULT)
-        curl.setopt(CurlOpt.TLS_GREASE, int(fp.tls_grease))
-        curl.setopt(CurlOpt.SSL_PERMUTE_EXTENSIONS, int(fp.tls_permute_extensions))
-        curl.setopt(CurlOpt.SSL_CERT_COMPRESSION, fp.tls_cert_compression)
-        curl.setopt(CurlOpt.STREAM_WEIGHT, fp.http2_stream_weight)
-        curl.setopt(CurlOpt.STREAM_EXCLUSIVE, fp.http2_stream_exclusive)
-
-    def _set_curl_options(
+    def _merge_curl_options(
         self,
         curl,
         method: HttpMethod,
@@ -461,326 +245,57 @@ class BaseSession:
         queue_class: Any = None,
         event_class: Any = None,
     ):
-        c = curl
-
-        method = method.upper()  # type: ignore
-
-        # method
-        if method == "POST":
-            c.setopt(CurlOpt.POST, 1)
-        elif method != "GET":
-            c.setopt(CurlOpt.CUSTOMREQUEST, method.encode())
-        if method == "HEAD":
-            c.setopt(CurlOpt.NOBODY, 1)
-
-        # url
+        """Merge curl options from session and request."""
         if self.params:
-            url = _update_url_params(url, self.params)
-        if params:
-            url = _update_url_params(url, params)
+            url = update_url_params(url, self.params)
         if self.base_url:
             url = urljoin(self.base_url, url)
-        if quote:
-            url = _quote_path_and_params(url, quote_str=quote)
-        if quote is not False:
-            url = requote_uri(url)
-        c.setopt(CurlOpt.URL, url.encode())
 
-        # data/body/json
-        if isinstance(data, (dict, list, tuple)):
-            body = urlencode(data).encode()
-        elif isinstance(data, str):
-            body = data.encode()
-        elif isinstance(data, BytesIO):
-            body = data.read()
-        elif isinstance(data, bytes):
-            body = data
-        elif data is None:
-            body = b""
-        else:
-            raise TypeError("data must be dict/list/tuple, str, BytesIO or bytes")
-        if json is not None:
-            body = dumps(json, separators=(",", ":")).encode()
+        _headers = Headers(self.headers)
+        _headers.update(headers)
 
-        # Tell libcurl to be aware of bodies and related headers when,
-        # 1. POST/PUT/PATCH, even if the body is empty, it's up to curl to decide what to do;
-        # 2. GET/DELETE with body, although it's against the RFC, some applications.
-        #   e.g. Elasticsearch, use this.
-        if body or method in ("POST", "PUT", "PATCH"):
-            c.setopt(CurlOpt.POSTFIELDS, body)
-            # necessary if body contains '\0'
-            c.setopt(CurlOpt.POSTFIELDSIZE, len(body))
-            if method == "GET":
-                c.setopt(CurlOpt.CUSTOMREQUEST, method)
-
-        # headers
-        h = Headers(self.headers)
-        h.update(headers)
-
-        # remove Host header if it's unnecessary, otherwise curl may get confused.
-        # Host header will be automatically added by curl if it's not present.
-        # https://github.com/lexiforest/curl_cffi/issues/119
-        host_header = h.get("Host")
-        if host_header is not None:
-            u = urlparse(url)
-            if host_header == u.netloc or host_header == u.hostname:
-                h.pop("Host", None)
-
-        # Make curl always include empty headers.
-        # See: https://stackoverflow.com/a/32911474/1061155
-        header_lines = []
-        for k, v in h.multi_items():
-            header_lines.append(f"{k}: {v}" if v else f"{k};")
-
-        # Add content-type if missing
-        if json is not None:
-            _update_header_line(header_lines, "Content-Type", "application/json", replace=True)
-        if isinstance(data, dict) and method != "POST":
-            _update_header_line(header_lines, "Content-Type", "application/x-www-form-urlencoded")
-        if isinstance(data, (str, bytes)):
-            _update_header_line(header_lines, "Content-Type", "application/octet-stream")
-
-        # Never send `Expect` header.
-        _update_header_line(header_lines, "Expect", "", replace=True)
-
-        c.setopt(CurlOpt.HTTPHEADER, [h.encode() for h in header_lines])
-
-        req = Request(url, h, method)
-
-        # cookies
-        c.setopt(CurlOpt.COOKIEFILE, b"")  # always enable the curl cookie engine first
-        c.setopt(CurlOpt.COOKIELIST, "ALL")  # remove all the old cookies first.
-
-        for morsel in self._cookies.get_cookies_for_curl(req):
-            # print("Setting", morsel.to_curl_format())
-            curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
-        if cookies:
-            temp_cookies = Cookies(cookies)
-            for morsel in temp_cookies.get_cookies_for_curl(req):
-                curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
-
-        # files
-        if files:
-            raise NotImplementedError(
-                "files is not supported, use `multipart`. See examples here: "
-                "https://github.com/lexiforest/curl_cffi/blob/main/examples/upload.py"
-            )
-
-        # multipart
-        if multipart:
-            # multipart will overrides postfields
-            for k, v in cast(dict, data or {}).items():
-                multipart.addpart(name=k, data=v.encode() if isinstance(v, str) else v)
-            c.setopt(CurlOpt.MIMEPOST, multipart._form)
-
-        # auth
-        if self.auth or auth:
-            if self.auth:
-                username, password = self.auth
-            if auth:
-                username, password = auth
-            c.setopt(CurlOpt.USERNAME, username.encode())  # pyright: ignore [reportPossiblyUnboundVariable=none]
-            c.setopt(CurlOpt.PASSWORD, password.encode())  # pyright: ignore [reportPossiblyUnboundVariable=none]
-
-        # timeout
-        if timeout is not_set:
-            timeout = self.timeout
-        if timeout is None:
-            timeout = 0  # indefinitely
-
-        if isinstance(timeout, tuple):
-            connect_timeout, read_timeout = timeout
-            all_timeout = connect_timeout + read_timeout
-            c.setopt(CurlOpt.CONNECTTIMEOUT_MS, int(connect_timeout * 1000))
-            if not stream:
-                c.setopt(CurlOpt.TIMEOUT_MS, int(all_timeout * 1000))
-            else:
-                # trick from: https://github.com/lexiforest/curl_cffi/issues/156
-                c.setopt(CurlOpt.LOW_SPEED_LIMIT, 1)
-                c.setopt(CurlOpt.LOW_SPEED_TIME, math.ceil(all_timeout))
-
-        elif isinstance(timeout, (int, float)):
-            if not stream:
-                c.setopt(CurlOpt.TIMEOUT_MS, int(timeout * 1000))
-            else:
-                c.setopt(CurlOpt.CONNECTTIMEOUT_MS, int(timeout * 1000))
-                c.setopt(CurlOpt.LOW_SPEED_LIMIT, 1)
-                c.setopt(CurlOpt.LOW_SPEED_TIME, math.ceil(timeout))
-
-        # allow_redirects
-        c.setopt(
-            CurlOpt.FOLLOWLOCATION,
-            int(self.allow_redirects if allow_redirects is None else allow_redirects),
-        )
-
-        # max_redirects
-        c.setopt(
-            CurlOpt.MAXREDIRS,
-            self.max_redirects if max_redirects is None else max_redirects,
-        )
-
-        # proxies
-        if proxy and proxies:
-            raise TypeError("Cannot specify both 'proxy' and 'proxies'")
-        if proxy:
-            proxies = {"all": proxy}
-        if proxies is None:
+        if proxy is None and proxies is None:
             proxies = self.proxies
 
-        if proxies:
-            parts = urlparse(url)
-            proxy = cast(Optional[str], proxies.get(parts.scheme, proxies.get("all")))
-            if parts.hostname:
-                proxy = (
-                    cast(
-                        Optional[str],
-                        proxies.get(
-                            f"{parts.scheme}://{parts.hostname}",
-                            proxies.get(f"all://{parts.hostname}"),
-                        ),
-                    )
-                    or proxy
-                )
-
-            if proxy is not None:
-                c.setopt(CurlOpt.PROXY, proxy)
-
-                if parts.scheme == "https":
-                    if proxy.startswith("https://"):
-                        warnings.warn(
-                            "Make sure you are using https over https proxy, otherwise, "
-                            "the proxy prefix should be 'http://' not 'https://', "
-                            "see: https://github.com/lexiforest/curl_cffi/issues/6",
-                            RuntimeWarning,
-                            stacklevel=2,
-                        )
-                    # For https site with http tunnel proxy, tell curl to enable tunneling
-                    if not proxy.startswith("socks"):
-                        c.setopt(CurlOpt.HTTPPROXYTUNNEL, 1)
-
-                # proxy_auth
-                proxy_auth = proxy_auth or self.proxy_auth
-                if proxy_auth:
-                    username, password = proxy_auth
-                    c.setopt(CurlOpt.PROXYUSERNAME, username.encode())
-                    c.setopt(CurlOpt.PROXYPASSWORD, password.encode())
-
-        # verify
-        if verify is False or not self.verify and verify is None:
-            c.setopt(CurlOpt.SSL_VERIFYPEER, 0)
-            c.setopt(CurlOpt.SSL_VERIFYHOST, 0)
-
-        # cert for this single request
-        if isinstance(verify, str):
-            c.setopt(CurlOpt.CAINFO, verify)
-
-        # cert for the session
-        if verify in (None, True) and isinstance(self.verify, str):
-            c.setopt(CurlOpt.CAINFO, self.verify)
-
-        # referer
-        if referer:
-            c.setopt(CurlOpt.REFERER, referer.encode())
-
-        # accept_encoding
-        if accept_encoding is not None:
-            c.setopt(CurlOpt.ACCEPT_ENCODING, accept_encoding.encode())
-
-        # cert
-        cert = cert or self.cert
-        if cert:
-            if isinstance(cert, str):
-                c.setopt(CurlOpt.SSLCERT, cert)
-            else:
-                cert, key = cert
-                c.setopt(CurlOpt.SSLCERT, cert)
-                c.setopt(CurlOpt.SSLKEY, key)
-
-        # impersonate
-        impersonate = impersonate or self.impersonate
-        default_headers = self.default_headers if default_headers is None else default_headers
-        if impersonate:
-            impersonate = normalize_browser_type(impersonate)
-            ret = c.impersonate(impersonate, default_headers=default_headers)
-            if ret != 0:
-                raise ImpersonateError(f"Impersonating {impersonate} is not supported")
-
-        # ja3 string
-        ja3 = ja3 or self.ja3
-        if ja3:
-            if impersonate:
-                warnings.warn("JA3 was altered after browser version was set.", stacklevel=1)
-            permute = False
-            if isinstance(extra_fp, ExtraFingerprints) and extra_fp.tls_permute_extensions:
-                permute = True
-            if isinstance(extra_fp, dict) and extra_fp.get("tls_permute_extensions"):
-                permute = True
-            self._set_ja3_options(c, ja3, permute=permute)
-
-        # akamai string
-        akamai = akamai or self.akamai
-        if akamai:
-            if impersonate:
-                warnings.warn("Akamai was altered after browser version was set.", stacklevel=1)
-            self._set_akamai_options(c, akamai)
-
-        # extra_fp options
-        extra_fp = extra_fp or self.extra_fp
-        if extra_fp:
-            if isinstance(extra_fp, dict):
-                extra_fp = ExtraFingerprints(**extra_fp)
-            if impersonate:
-                warnings.warn(
-                    "Extra fingerprints was altered after browser version was set.",
-                    stacklevel=1,
-                )
-            self._set_extra_fp(c, extra_fp)
-
-        # http_version, after impersonate, which will change this to http2
-        http_version = http_version or self.http_version
-        if http_version:
-            c.setopt(CurlOpt.HTTP_VERSION, http_version)
-
-        # set extra curl options, must come after impersonate, because it will alter some options
-        for k, v in self.curl_options.items():
-            c.setopt(k, v)
-
-        buffer = None
-        q = None
-        header_recved = None
-        quit_now = None
-        if stream:
-            q = queue_class()
-            header_recved = event_class()
-            quit_now = event_class()
-
-            def qput(chunk):
-                if not header_recved.is_set():
-                    header_recved.set()
-                if quit_now.is_set():
-                    return CURL_WRITEFUNC_ERROR
-                q.put_nowait(chunk)
-                return len(chunk)
-
-            c.setopt(CurlOpt.WRITEFUNCTION, qput)
-        elif content_callback is not None:
-            c.setopt(CurlOpt.WRITEFUNCTION, content_callback)
-        else:
-            buffer = BytesIO()
-            c.setopt(CurlOpt.WRITEDATA, buffer)
-        header_buffer = BytesIO()
-        c.setopt(CurlOpt.HEADERDATA, header_buffer)
-
-        # interface
-        interface = interface or self.interface
-        if interface:
-            c.setopt(CurlOpt.INTERFACE, interface.encode())
-
-        # max_recv_speed
-        # do not check, since 0 is a valid value to disable it
-        c.setopt(CurlOpt.MAX_RECV_SPEED_LARGE, max_recv_speed)
-
-        return req, buffer, header_buffer, q, header_recved, quit_now
+        return set_curl_options(
+            curl,
+            method=method,
+            url=url,
+            params=params,
+            data=data,
+            json=json,
+            headers=_headers,
+            cookies=cookies,
+            session_cookies=self._cookies,
+            files=files,
+            auth=auth or self.auth,
+            timeout=self.timeout if timeout is not_set else timeout,
+            allow_redirects=self.allow_redirects if allow_redirects is None else allow_redirects,
+            max_redirects=self.max_redirects if max_redirects is None else max_redirects,
+            proxies=proxies,
+            proxy=proxy,
+            proxy_auth=proxy_auth or self.proxy_auth,
+            verify=verify,
+            session_verify=self.verify,
+            referer=referer,
+            accept_encoding=accept_encoding,
+            content_callback=content_callback,
+            impersonate=impersonate or self.impersonate,
+            ja3=ja3 or self.ja3,
+            akamai=akamai or self.akamai,
+            extra_fp=extra_fp or self.extra_fp,
+            default_headers=self.default_headers if default_headers is None else default_headers,
+            quote=quote,
+            http_version=http_version or self.http_version,
+            interface=interface or self.interface,
+            stream=stream,
+            max_recv_speed=max_recv_speed,
+            multipart=multipart,
+            cert=cert or self.cert,
+            queue_class=queue_class,
+            event_class=event_class,
+            curl_options=self.curl_options,
+        )
 
     def _parse_response(self, curl, buffer, header_buffer, default_encoding):
         c = curl
@@ -948,47 +463,6 @@ class Session(BaseSession):
         finally:
             rsp.close()
 
-    def ws_connect(
-        self,
-        url,
-        *args,
-        on_message: Optional[ON_MESSAGE_T] = None,
-        on_error: Optional[ON_ERROR_T] = None,
-        on_open: Optional[ON_OPEN_T] = None,
-        on_close: Optional[ON_CLOSE_T] = None,
-        **kwargs,
-    ) -> WebSocket:
-        """Connects to a websocket url.
-
-        Args:
-            url: the ws url to connect.
-            on_message: message callback, ``def on_message(ws, str)``
-            on_error: error callback, ``def on_error(ws, error)``
-            on_open: open callback, ``def on_open(ws)``
-            on_close: close callback, ``def on_close(ws)``
-
-        Other parameters are the same as ``.request``
-
-        Returns:
-            a ws instance to communicate with the server.
-        """
-        self._check_session_closed()
-
-        self._set_curl_options(self.curl, "GET", url, *args, **kwargs)
-
-        # https://curl.se/docs/websocket.html
-        self.curl.setopt(CurlOpt.CONNECT_ONLY, 2)
-        self.curl.perform()
-
-        return WebSocket(
-            self,
-            self.curl,
-            on_message=on_message,
-            on_error=on_error,
-            on_open=on_open,
-            on_close=on_close,
-        )
-
     def request(
         self,
         method: HttpMethod,
@@ -1035,7 +509,7 @@ class Session(BaseSession):
         else:
             c = self.curl
 
-        req, buffer, header_buffer, q, header_recved, quit_now = self._set_curl_options(
+        req, buffer, header_buffer, q, header_recved, quit_now = self._merge_curl_options(
             c,
             method=method,
             url=url,
@@ -1277,15 +751,117 @@ class AsyncSession(BaseSession):
         finally:
             await rsp.aclose()
 
-    async def ws_connect(self, url, *args, **kwargs):
+    async def ws_connect(
+        self,
+        url: str,
+        autoclose: bool = True,
+        params: Optional[Union[Dict, List, Tuple]] = None,
+        headers: Optional[HeaderTypes] = None,
+        cookies: Optional[CookieTypes] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        timeout: Optional[Union[float, Tuple[float, float], object]] = not_set,
+        allow_redirects: Optional[bool] = None,
+        max_redirects: Optional[int] = None,
+        proxies: Optional[ProxySpec] = None,
+        proxy: Optional[str] = None,
+        proxy_auth: Optional[Tuple[str, str]] = None,
+        verify: Optional[bool] = None,
+        referer: Optional[str] = None,
+        accept_encoding: Optional[str] = "gzip, deflate, br",
+        impersonate: Optional[BrowserTypeLiteral] = None,
+        ja3: Optional[str] = None,
+        akamai: Optional[str] = None,
+        extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
+        default_headers: Optional[bool] = None,
+        default_encoding: Union[str, Callable[[bytes], str]] = "utf-8",
+        quote: Union[str, Literal[False]] = "",
+        http_version: Optional[CurlHttpVersion] = None,
+        interface: Optional[str] = None,
+        cert: Optional[Union[str, Tuple[str, str]]] = None,
+        max_recv_speed: int = 0,
+    ):
+        """Connects to a WebSocket.
+
+        Parameters:
+            url: url for the requests.
+            autoclose: whether to close the WebSocket after receiving a close frame.
+            params: query string for the requests.
+            headers: headers to send.
+            cookies: cookies to use.
+            auth: HTTP basic auth, a tuple of (username, password), only basic auth is supported.
+            timeout: how many seconds to wait before giving up.
+            allow_redirects: whether to allow redirection.
+            max_redirects: max redirect counts, default 30, use -1 for unlimited.
+            proxies: dict of proxies to use, format: ``{"http": proxy_url, "https": proxy_url}``.
+            proxy: proxy to use, format: "http://user@pass:proxy_url".
+                Can't be used with `proxies` parameter.
+            proxy_auth: HTTP basic auth for proxy, a tuple of (username, password).
+            verify: whether to verify https certs.
+            referer: shortcut for setting referer header.
+            accept_encoding: shortcut for setting accept-encoding header.
+            impersonate: which browser version to impersonate.
+            ja3: ja3 string to impersonate.
+            akamai: akamai string to impersonate.
+            extra_fp: extra fingerprints options, in complement to ja3 and akamai strings.
+            default_headers: whether to set default browser headers.
+            default_encoding: encoding for decoding response content if charset is not found
+                in headers. Defaults to "utf-8". Can be set to a callable for automatic detection.
+            quote: Set characters to be quoted, i.e. percent-encoded. Default safe string
+                is ``!#$%&'()*+,/:;=?@[]~``. If set to a sting, the character will be removed
+                from the safe string, thus quoted. If set to False, the url will be kept as is,
+                without any automatic percent-encoding, you must encode the URL yourself.
+            curl_options: extra curl options to use.
+            http_version: limiting http version, defaults to http2.
+            interface: which interface to use.
+            cert: a tuple of (cert, key) filenames for client cert.
+            max_recv_speed: maximum receive speed, bytes per second.
+        """
         self._check_session_closed()
 
         curl = await self.pop_curl()
-        # curl.debug()
-        self._set_curl_options(curl, "GET", url, *args, **kwargs)
+        req, buffer, header_buffer, *_ = self._merge_curl_options(
+            curl=curl,
+            method="GET",
+            url=url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            max_redirects=max_redirects,
+            proxies=proxies,
+            proxy=proxy,
+            proxy_auth=proxy_auth,
+            verify=verify,
+            referer=referer,
+            accept_encoding=accept_encoding,
+            impersonate=impersonate,
+            ja3=ja3,
+            akamai=akamai,
+            extra_fp=extra_fp,
+            default_headers=default_headers,
+            quote=quote,
+            http_version=http_version,
+            interface=interface,
+            max_recv_speed=max_recv_speed,
+            cert=cert,
+            queue_class=asyncio.Queue,
+            event_class=asyncio.Event,
+        )
         curl.setopt(CurlOpt.CONNECT_ONLY, 2)  # https://curl.se/docs/websocket.html
-        await self.loop.run_in_executor(None, curl.perform)
-        return WebSocket(self, curl)
+
+        try:
+            task = self.acurl.add_handle(curl)
+            await task
+        except CurlError as e:
+            rsp = self._parse_response(curl, buffer, header_buffer, default_encoding)
+            rsp.request = req
+            error = code2error(e.code, str(e))
+            self.release_curl(curl)
+            raise error(str(e), e.code, rsp) from e
+        else:
+            return AsyncWebSocket(self, curl, autoclose=autoclose)
 
     async def request(
         self,
@@ -1326,7 +902,7 @@ class AsyncSession(BaseSession):
         self._check_session_closed()
 
         curl = await self.pop_curl()
-        req, buffer, header_buffer, q, header_recved, quit_now = self._set_curl_options(
+        req, buffer, header_buffer, q, header_recved, quit_now = self._merge_curl_options(
             curl=curl,
             method=method,
             url=url,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -771,7 +771,6 @@ class AsyncSession(BaseSession):
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
         default_headers: Optional[bool] = None,
-        default_encoding: Union[str, Callable[[bytes], str]] = "utf-8",
         quote: Union[str, Literal[False]] = "",
         http_version: Optional[CurlHttpVersion] = None,
         interface: Optional[str] = None,
@@ -802,8 +801,6 @@ class AsyncSession(BaseSession):
             akamai: akamai string to impersonate.
             extra_fp: extra fingerprints options, in complement to ja3 and akamai strings.
             default_headers: whether to set default browser headers.
-            default_encoding: encoding for decoding response content if charset is not found
-                in headers. Defaults to "utf-8". Can be set to a callable for automatic detection.
             quote: Set characters to be quoted, i.e. percent-encoded. Default safe string
                 is ``!#$%&'()*+,/:;=?@[]~``. If set to a sting, the character will be removed
                 from the safe string, thus quoted. If set to False, the url will be kept as is,
@@ -849,7 +846,7 @@ class AsyncSession(BaseSession):
         )
         curl.setopt(CurlOpt.CONNECT_ONLY, 2)  # https://curl.se/docs/websocket.html
 
-        self.loop.run_in_executor(None, curl.perform)
+        await self.loop.run_in_executor(None, curl.perform)
         return AsyncWebSocket(self, curl, autoclose=autoclose)
 
     async def request(

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -22,18 +22,15 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import ParseResult, parse_qsl, quote, urlencode, urlparse
+from urllib.parse import urlparse
 
-from .. import AsyncCurl, Curl, CurlError, CurlHttpVersion, CurlInfo, CurlOpt, CurlSslVersion
-from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
+from ..aio import AsyncCurl
+from ..const import CurlHttpVersion, CurlInfo, CurlOpt
+from ..curl import Curl, CurlError, CurlMime
 from .cookies import Cookies, CookieTypes, CurlMorsel
 from .exceptions import RequestException, SessionClosed, code2error
 from .headers import Headers, HeaderTypes
-from .impersonate import (
-    BrowserTypeLiteral,
-    ExtraFingerprints,
-    ExtraFpDict,
-)
+from .impersonate import BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
 from .models import Response
 from .options import set_curl_options, update_url_params
 from .websockets import AsyncWebSocket
@@ -97,21 +94,6 @@ def _is_absolute_url(url: str) -> bool:
 
 
 SAFE_CHARS = set("!#$%&'()*+,/:;=?@[]~")
-
-
-def _quote_path_and_params(url: str, quote_str: str = ""):
-    safe = "".join(SAFE_CHARS - set(quote_str))
-    parsed_url = urlparse(url)
-    parsed_get_args = parse_qsl(parsed_url.query, keep_blank_values=True)
-    encoded_get_args = urlencode(parsed_get_args, doseq=True, safe=safe)
-    return ParseResult(
-        parsed_url.scheme,
-        parsed_url.netloc,
-        quote(parsed_url.path, safe=safe),
-        parsed_url.params,
-        encoded_get_args,
-        parsed_url.fragment,
-    ).geturl()
 
 
 def _peek_queue(q: queue.Queue, default=None):

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -437,7 +437,7 @@ def set_curl_options(
     base_cookies, cookies = cookies_list
 
     if base_cookies:
-        for morsel in base_cookies.get_cookies_for_curl(req):
+        for morsel in base_cookies.get_cookies_for_curl(req):  # type: ignore
             curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
     if cookies:
         temp_cookies = Cookies(cookies)
@@ -488,7 +488,7 @@ def set_curl_options(
             c.setopt(CurlOpt.LOW_SPEED_TIME, math.ceil(timeout))
 
     # allow_redirects
-    c.setopt(CurlOpt.FOLLOWLOCATION, int(allow_redirects))
+    c.setopt(CurlOpt.FOLLOWLOCATION, int(allow_redirects))  # type: ignore
 
     # max_redirects
     c.setopt(CurlOpt.MAXREDIRS, max_redirects)

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -222,7 +222,7 @@ class WebSocket(BaseWebSocket):
         interface: Optional[str] = None,
         cert: Optional[Union[str, Tuple[str, str]]] = None,
         max_recv_speed: int = 0,
-        curl_options: Optional[dict] = None,
+        curl_options: Optional[Dict[CurlOpt, str]] = None,
     ):
         """Connect to the WebSocket.
 
@@ -466,7 +466,7 @@ class WebSocket(BaseWebSocket):
                 if "message" in self._emitters:
                     if (flags & CurlWsFlag.TEXT) and not self.skip_utf8_validation:
                         try:
-                            msg = msg.decode()
+                            msg = msg.decode()  # type: ignore
                         except UnicodeDecodeError:
                             self._close_code = WsCloseCode.INVALID_DATA
                             self.close(WsCloseCode.INVALID_DATA)

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -524,7 +524,7 @@ class AsyncWebSocket(BaseWebSocket):
             self._loop = asyncio.get_running_loop()
         return self._loop
 
-    async def __aiter__(self) -> Self:
+    def __aiter__(self) -> Self:
         if self.closed:
             raise SessionClosed("WebSocket is closed")
         return self

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -1,19 +1,37 @@
+from __future__ import annotations
+
 import asyncio
-import select
+from select import select
 import struct
 from enum import IntEnum
-from typing import Callable, Optional, Tuple
+from json import loads, dumps
+from typing import Any, Callable, Dict, Final, List, Literal, Optional, Tuple, TYPE_CHECKING, TypeVar, Union
 
+from .options import set_curl_options
 from .._wrapper import ffi, lib
 from ..aio import CURL_SOCKET_BAD
-from ..const import CurlECode, CurlWsFlag, CurlInfo
-from ..curl import CurlError
+from ..const import CurlECode, CurlOpt, CurlWsFlag, CurlInfo
+from ..curl import Curl, CurlError
 
-ON_MESSAGE_T = Callable[["WebSocket", bytes], None]
-ON_ERROR_T = Callable[["WebSocket", CurlError], None]
-ON_OPEN_T = Callable[["WebSocket"], None]
-ON_CLOSE_T = Callable[["WebSocket", int, str], None]
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
+    from .cookies import CookieTypes
+    from .headers import HeaderTypes
+    from .impersonate import BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
+    from .session import AsyncSession, ProxySpec
+    from ..const import CurlHttpVersion
+    from ..curl import CurlWsFrame
+
+    T = TypeVar("T")
+
+    ON_DATA_T = Callable[["WebSocket", bytes, CurlWsFrame], None]
+    ON_MESSAGE_T = Callable[["WebSocket", Union[bytes, str]], None]
+    ON_ERROR_T = Callable[["WebSocket", CurlError], None]
+    ON_OPEN_T = Callable[["WebSocket"], None]
+    ON_CLOSE_T = Callable[["WebSocket", int, str], None]
+
+not_set: Final[Any] = object()
 
 class WsCloseCode(IntEnum):
     OK = 1000
@@ -33,30 +51,268 @@ class WsCloseCode(IntEnum):
 
 
 class WebSocketError(CurlError):
-    pass
+    """WebSocket-specific error."""
+
+    def __init__(self, message: str, code: Union[WsCloseCode, CurlECode, Literal[0]] = 0):
+        super().__init__(message, code)  # type: ignore
 
 
-class WebSocket:
+async def aselect(fd, *, loop: asyncio.AbstractEventLoop, timeout: Optional[float] = None) -> bool:
+    future = loop.create_future()
+    loop.add_reader(fd, future.set_result, None)
+    future.add_done_callback(lambda _: loop.remove_reader(fd))
+    try:
+        await asyncio.wait_for(future, timeout)
+    except asyncio.TimeoutError:
+        return False
+    return True
+
+
+class BaseWebSocket:
+    def __init__(self, curl: Curl, *, autoclose: bool = True):
+        self.curl: Curl = curl
+        self.autoclose: bool = autoclose
+        self._close_code: Optional[int] = None
+        self._close_reason: Optional[str] = None
+
+    @property
+    def closed(self) -> bool:
+        """Whether the WebSocket is closed."""
+        return self.curl is not_set
+
+    @property
+    def close_code(self) -> Optional[int]:
+        """The WebSocket close code, if the connection is closed."""
+        return self._close_code
+
+    @property
+    def close_reason(self) -> Optional[str]:
+        """The WebSocket close reason, if the connection is closed."""
+        return self._close_reason
+
+    @staticmethod
+    def _pack_close_frame(code: int, reason: bytes) -> bytes:
+        return struct.pack("!H", code) + reason
+
+    @staticmethod
+    def _unpack_close_frame(frame: bytes) -> Tuple[int, str]:
+        if len(frame) < 2:
+            code = WsCloseCode.UNKNOWN
+            reason = ""
+        else:
+            try:
+                code = struct.unpack_from("!H", frame)[0]
+                reason = frame[2:].decode()
+            except UnicodeDecodeError:
+                raise WebSocketError("Invalid close message", WsCloseCode.INVALID_DATA)
+            except Exception:
+                raise WebSocketError("Invalid close frame", WsCloseCode.PROTOCOL_ERROR)
+            else:
+                if code < 3000 and (code not in WsCloseCode or code == 1005):
+                    raise WebSocketError("Invalid close code", WsCloseCode.PROTOCOL_ERROR)
+        return code, reason
+
+    def terminate(self):
+        """Terminate the underlying connection."""
+        if self.curl is not_set:
+            return
+        self.curl.close()
+        self.curl = not_set
+
+
+class WebSocket(BaseWebSocket):
+    """A WebSocket implementation using libcurl."""
+
     def __init__(
         self,
-        session,
-        curl,
-        on_message: Optional[ON_MESSAGE_T] = None,
-        on_error: Optional[ON_ERROR_T] = None,
+        *,
+        autoclose: bool = True,
+        skip_utf8_validation: bool = False,
+        debug: bool = False,
         on_open: Optional[ON_OPEN_T] = None,
         on_close: Optional[ON_CLOSE_T] = None,
+        on_data: Optional[ON_DATA_T] = None,
+        on_message: Optional[ON_MESSAGE_T] = None,
+        on_error: Optional[ON_ERROR_T] = None,
     ):
-        self.session = session
-        self.curl = curl
-        self.on_message = on_message
-        self.on_error = on_error
-        self.on_open = on_open
-        self.on_close = on_close
-        self.keep_running = True
-        self._loop = None
+        """
+        Parameters:
+            autoclose: whether to close the WebSocket after receiving a close frame.
+            skip_utf8_validation: whether to skip UTF-8 validation for text frames in run_forever().
+            debug: print extra curl debug info.
 
-    def recv_fragment(self):
-        return self.curl.ws_recv()
+            on_open: open callback, ``def on_open(ws)``
+            on_close: close callback, ``def on_close(ws, code, reason)``
+            on_data: raw data receive callback, ``def on_data(ws, data, frame)``
+            on_message: message receive callback, ``def on_message(ws, message)``
+            on_error: error callback, ``def on_error(ws, exception)``
+        """
+        super().__init__(not_set, autoclose=autoclose)
+        self.skip_utf8_validation = skip_utf8_validation
+        self.debug = debug
+
+        self._emitters: dict[str, Callable] = {}
+        if on_open:
+            self._emitters["open"] = on_open
+        if on_close:
+            self._emitters["close"] = on_close
+        if on_data:
+            self._emitters["data"] = on_data
+        if on_message:
+            self._emitters["message"] = on_message
+        if on_error:
+            self._emitters["error"] = on_error
+
+    def __iter__(self) -> WebSocket:
+        if self.closed:
+            raise TypeError("WebSocket is closed")
+        return self
+
+    def __next__(self) -> bytes:
+        msg, flags = self.recv()
+        if flags & CurlWsFlag.CLOSE:
+            raise StopIteration
+        return msg
+
+    def _emit(self, event_type: str, *args) -> None:
+        callback = self._emitters.get(event_type)
+        if callback:
+            try:
+                callback(self, *args)
+            except Exception as e:
+                error_callback = self._emitters.get("error")
+                if error_callback:
+                    error_callback(self, e)
+
+    def connect(
+        self,
+        url: str,
+        params: Optional[Union[Dict, List, Tuple]] = None,
+        headers: Optional[HeaderTypes] = None,
+        cookies: Optional[CookieTypes] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        timeout: Optional[Union[float, Tuple[float, float], object]] = not_set,
+        allow_redirects: bool = True,
+        max_redirects: int = 30,
+        proxies: Optional[ProxySpec] = None,
+        proxy: Optional[str] = None,
+        proxy_auth: Optional[Tuple[str, str]] = None,
+        verify: Optional[bool] = None,
+        referer: Optional[str] = None,
+        accept_encoding: Optional[str] = "gzip, deflate, br",
+        impersonate: Optional[BrowserTypeLiteral] = None,
+        ja3: Optional[str] = None,
+        akamai: Optional[str] = None,
+        extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
+        default_headers: bool = True,
+        quote: Union[str, Literal[False]] = "",
+        http_version: Optional[CurlHttpVersion] = None,
+        interface: Optional[str] = None,
+        cert: Optional[Union[str, Tuple[str, str]]] = None,
+        max_recv_speed: int = 0,
+        curl_options: Optional[dict] = None,
+    ):
+        """Connect to the WebSocket.
+
+        libcurl automatically handles pings and pongs.
+        ref: https://curl.se/libcurl/c/libcurl-ws.html
+
+        Parameters:
+            url: url for the requests.
+            params: query string for the requests.
+            headers: headers to send.
+            cookies: cookies to use.
+            auth: HTTP basic auth, a tuple of (username, password), only basic auth is supported.
+            timeout: how many seconds to wait before giving up.
+            allow_redirects: whether to allow redirection.
+            max_redirects: max redirect counts, default 30, use -1 for unlimited.
+            proxies: dict of proxies to use, format: ``{"http": proxy_url, "https": proxy_url}``.
+            proxy: proxy to use, format: "http://user@pass:proxy_url".
+                Can't be used with `proxies` parameter.
+            proxy_auth: HTTP basic auth for proxy, a tuple of (username, password).
+            verify: whether to verify https certs.
+            referer: shortcut for setting referer header.
+            accept_encoding: shortcut for setting accept-encoding header.
+            impersonate: which browser version to impersonate.
+            ja3: ja3 string to impersonate.
+            akamai: akamai string to impersonate.
+            extra_fp: extra fingerprints options, in complement to ja3 and akamai strings.
+            default_headers: whether to set default browser headers.
+            default_encoding: encoding for decoding response content if charset is not found
+                in headers. Defaults to "utf-8". Can be set to a callable for automatic detection.
+            quote: Set characters to be quoted, i.e. percent-encoded. Default safe string
+                is ``!#$%&'()*+,/:;=?@[]~``. If set to a sting, the character will be removed
+                from the safe string, thus quoted. If set to False, the url will be kept as is,
+                without any automatic percent-encoding, you must encode the URL yourself.
+            curl_options: extra curl options to use.
+            http_version: limiting http version, defaults to http2.
+            interface: which interface to use.
+            cert: a tuple of (cert, key) filenames for client cert.
+            max_recv_speed: maximum receive speed, bytes per second.
+            curl_options: extra curl options to use.
+        """
+        if not self.closed:
+            raise TypeError("WebSocket is already connected")
+
+        if proxy and proxies:
+            raise TypeError("Cannot specify both 'proxy' and 'proxies'")
+        if proxy:
+            proxies = {"all": proxy}
+
+        self.curl = curl = Curl(debug=self.debug)
+        set_curl_options(
+            curl=curl,
+            method="GET",
+            url=url,
+            params=params,
+            headers=headers,
+            cookies=cookies,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            max_redirects=max_redirects,
+            proxies=proxies,
+            proxy=proxy,
+            proxy_auth=proxy_auth,
+            verify=verify,
+            referer=referer,
+            accept_encoding=accept_encoding,
+            impersonate=impersonate,
+            ja3=ja3,
+            akamai=akamai,
+            extra_fp=extra_fp,
+            default_headers=default_headers,
+            quote=quote,
+            http_version=http_version,
+            interface=interface,
+            max_recv_speed=max_recv_speed,
+            cert=cert,
+            curl_options=curl_options,
+        )
+
+        # https://curl.se/docs/websocket.html
+        curl.setopt(CurlOpt.CONNECT_ONLY, 2)
+        curl.perform()
+
+    def recv_fragment(self) -> Tuple[bytes, CurlWsFrame]:
+        """Receive a single frame as bytes."""
+        if self.closed:
+            raise TypeError("WebSocket is closed")
+
+        chunk, frame = self.curl.ws_recv()
+        if frame.flags & CurlWsFlag.CLOSE:
+            try:
+                self._close_code, self._close_reason = self._unpack_close_frame(chunk)
+            except WebSocketError as e:
+                # Follow the spec to close the connection
+                # Errors do not respect autoclose
+                self._close_code = e.code
+                self.close(e.code)
+                raise
+            if self.autoclose:
+                self.close()
+
+        return chunk, frame
 
     def recv(self) -> Tuple[bytes, int]:
         """
@@ -67,16 +323,15 @@ class WebSocket:
         """
         chunks = []
         flags = 0
+
         sock_fd = self.curl.getinfo(CurlInfo.ACTIVESOCKET)
         if sock_fd == CURL_SOCKET_BAD:
-            raise WebSocketError(
-                "Invalid active socket", CurlECode.NO_CONNECTION_AVAILABLE
-            )
+            raise WebSocketError("Invalid active socket", CurlECode.NO_CONNECTION_AVAILABLE)
         while True:
             try:
-                rlist, _, _ = select.select([sock_fd], [], [], 5.0)
+                rlist, _, _ = select([sock_fd], [], [], 5.0)
                 if rlist:
-                    chunk, frame = self.curl.ws_recv()
+                    chunk, frame = self.recv_fragment()
                     flags = frame.flags
                     chunks.append(chunk)
                     if frame.bytesleft == 0 and flags & CurlWsFlag.CONT == 0:
@@ -89,66 +344,165 @@ class WebSocket:
 
         return b"".join(chunks), flags
 
-    def send(self, payload: bytes, flags: CurlWsFlag = CurlWsFlag.BINARY):
-        """Send a data frame"""
+    def recv_str(self) -> str:
+        """Receive a text frame."""
+        data, flags = self.recv()
+        if not flags & CurlWsFlag.TEXT:
+            raise TypeError("Received non-text frame")
+        return data.decode()
+
+    def recv_json(self, *, loads: Callable[[str], T] = loads) -> T:
+        """Receive a JSON frame.
+
+        Parameters:
+            loads: JSON decoder, default is json.loads.
+        """
+        data = self.recv_str()
+        return loads(data)
+
+    def send(self, payload: Union[str, bytes], flags: CurlWsFlag = CurlWsFlag.BINARY):
+        """Send a data frame.
+
+        Parameters:
+            payload: data to send.
+            flags: flags for the frame.
+        """
+        if self.closed:
+            raise TypeError("WebSocket is closed")
+
+        # curl expects bytes
+        if isinstance(payload, str):
+            payload = payload.encode()
         return self.curl.ws_send(payload, flags)
 
-    def run_forever(self):
-        """
-        libcurl automatically handles pings and pongs.
+    def send_binary(self, payload: bytes):
+        """Send a binary frame.
 
+        Parameters:
+            payload: binary data to send.
+        """
+        return self.send(payload, CurlWsFlag.BINARY)
+
+    def send_bytes(self, payload: bytes):
+        """Send a binary frame. Same as :meth:`send_binary`.
+
+        Parameters:
+            payload: binary data to send.
+        """
+        return self.send(payload, CurlWsFlag.BINARY)
+
+    def send_str(self, payload: str):
+        """Send a text frame.
+
+        Parameters:
+            payload: text data to send.
+        """
+        return self.send(payload, CurlWsFlag.TEXT)
+
+    def send_json(self, payload: Any, *, dumps: Callable[[Any], str] = dumps):
+        """Send a JSON frame.
+
+        Parameters:
+            payload: data to send.
+            dumps: JSON encoder, default is json.dumps.
+        """
+        return self.send_str(dumps(payload))
+
+    def ping(self, payload: Union[str, bytes]):
+        """Send a ping frame.
+
+        Parameters:
+            payload: data to send.
+        """
+        return self.send(payload, CurlWsFlag.PING)
+
+    def run_forever(self, url: str, **kwargs):
+        """Run the WebSocket forever. See :meth:`connect` for details on parameters.
+
+        libcurl automatically handles pings and pongs.
         ref: https://curl.se/libcurl/c/libcurl-ws.html
         """
-        if self.on_open:
-            self.on_open(self)
+        if not self.closed:
+            raise TypeError("WebSocket is already connected")
+
+        self.connect(url, **kwargs)
+        sock_fd = self.curl.getinfo(CurlInfo.ACTIVESOCKET)
+        if sock_fd == CURL_SOCKET_BAD:
+            raise WebSocketError("Invalid active socket", CurlECode.NO_CONNECTION_AVAILABLE)
+
+        self._emit("open")
 
         # Keep reading the messages and invoke callbacks
-        while self.keep_running:
+        # TODO: Reconnect logic
+        chunks = []
+        keep_running = True
+        while keep_running:
             try:
-                msg, flags = self.recv()
-                if self.on_message:
-                    self.on_message(self, msg)
-                if flags & CurlWsFlag.CLOSE:
-                    self.keep_running = False
-                    # Unpack close code and reason
-                    if len(msg) < 2:
-                        code = WsCloseCode.UNKNOWN
-                        reason = ""
-                    else:
+                rlist, _, _ = select([sock_fd], [], [], 5.0)
+                if not rlist:
+                    continue
+
+                msg, frame = self.recv_fragment()
+                flags = frame.flags
+                self._emit("data", msg, frame)
+
+                if not (frame.bytesleft == 0 and flags & CurlWsFlag.CONT == 0):
+                    chunks.append(msg)
+                    continue
+
+                # Avoid unnecessary computation
+                if "message" in self._emitters:
+                    if (flags & CurlWsFlag.TEXT) and not self.skip_utf8_validation:
                         try:
-                            code = struct.unpack_from("!H", msg)[0]
-                            reason = msg[2:].decode()
-                        except UnicodeDecodeError as e:
-                            raise WebSocketError(
-                                "Invalid close message", WsCloseCode.INVALID_DATA
-                            ) from e
-                        except Exception as e:
-                            raise WebSocketError(
-                                "Invalid close frame", WsCloseCode.PROTOCOL_ERROR
-                            ) from e
-                        else:
-                            if code < 3000 and (code not in WsCloseCode or code == 1005):
-                                raise WebSocketError(
-                                    "Invalid close code", WsCloseCode.PROTOCOL_ERROR
-                                )
-                    if self.on_close:
-                        self.on_close(self, code, reason)
-            except WebSocketError as e:
-                # Follow the spec to close the connection
-                # TODO: Consider adding setting to autoclose connection on error-free close
-                self.close(e.code)
-                if self.on_error:
-                    self.on_error(self, e)
+                            msg = msg.decode()
+                        except UnicodeDecodeError:
+                            self._close_code = WsCloseCode.INVALID_DATA
+                            self.close(WsCloseCode.INVALID_DATA)
+                            raise WebSocketError("Invalid UTF-8", WsCloseCode.INVALID_DATA)
+                    if (flags & CurlWsFlag.BINARY) or (flags & CurlWsFlag.TEXT):
+                        self._emit("message", msg)
+                if flags & CurlWsFlag.CLOSE:
+                    keep_running = False
+                    self._emit("close", self._close_code or 0, self._close_reason or "")
             except CurlError as e:
-                if self.on_error:
-                    self.on_error(self, e)
+                if e.code == CurlECode.AGAIN:
+                    pass
+                else:
+                    self._emit("error", e)
+                    if not self.closed:
+                        code = 1000
+                        if isinstance(e, WebSocketError):
+                            code = e.code
+                        self.close(code)
+                    raise
 
     def close(self, code: int = WsCloseCode.OK, message: bytes = b""):
-        msg = struct.pack("!H", code) + message
-        # FIXME how to reset, or can a curl handle connect to two websockets?
+        """Close the connection.
+
+        Parameters:
+            code: close code.
+            message: close reason.
+        """
+        if self.curl is not_set:
+            return
+
+        # TODO: As per spec, we should wait for the server to close the connection
+        # But this is not a requirement
+        msg = self._pack_close_frame(code, message)
         self.send(msg, CurlWsFlag.CLOSE)
-        self.keep_running = False
-        self.curl.close()
+        # The only way to close the connection appears to be curl_easy_cleanup
+        self.terminate()
+
+
+class AsyncWebSocket(BaseWebSocket):
+    """An async WebSocket implementation using libcurl."""
+
+    def __init__(self, session: AsyncSession, curl: Curl, *, autoclose: bool = True):
+        super().__init__(curl, autoclose=autoclose)
+        self.session = session
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._recv_lock = asyncio.Lock()
+        self._send_lock = asyncio.Lock()
 
     @property
     def loop(self):
@@ -156,13 +510,178 @@ class WebSocket:
             self._loop = asyncio.get_running_loop()
         return self._loop
 
-    async def arecv(self) -> Tuple[bytes, int]:
-        return await self.loop.run_in_executor(None, self.recv)
+    async def __aiter__(self) -> Self:
+        if self.closed:
+            raise TypeError("WebSocket is closed")
+        return self
 
-    async def asend(self, payload: bytes, flags: CurlWsFlag = CurlWsFlag.BINARY):
-        return await self.loop.run_in_executor(None, self.send, payload, flags)
+    async def __anext__(self) -> bytes:
+        msg, flags = await self.recv()
+        if flags & CurlWsFlag.CLOSE:
+            raise StopAsyncIteration
+        return msg
 
-    async def aclose(self, code: int = WsCloseCode.OK, message: bytes = b""):
-        await self.loop.run_in_executor(None, self.close, code, message)
-        self.curl.reset()
-        self.session.push_curl(self.curl)
+    async def recv_fragment(self, *, timeout: Optional[float] = None) -> Tuple[bytes, CurlWsFrame]:
+        """Receive a single frame as bytes.
+
+        Parameters:
+            timeout: how many seconds to wait before giving up.
+        """
+        if self.closed:
+            raise TypeError("WebSocket is closed")
+        if self._recv_lock.locked():
+            raise TypeError("Concurrent call to recv_fragment() is not allowed")
+
+        async with self._recv_lock:
+            chunk, frame = await asyncio.wait_for(self.loop.run_in_executor(None, self.curl.ws_recv), timeout)
+            if frame.flags & CurlWsFlag.CLOSE:
+                try:
+                    self._close_code, self._close_reason = self._unpack_close_frame(chunk)
+                except WebSocketError as e:
+                    # Follow the spec to close the connection
+                    # Errors do not respect autoclose
+                    self._close_code = e.code
+                    await self.close(e.code)
+                    raise
+                if self.autoclose:
+                    await self.close()
+
+        return chunk, frame
+
+    async def recv(self, *, timeout: Optional[float] = None) -> Tuple[bytes, int]:
+        """
+        Receive a frame as bytes.
+
+        libcurl split frames into fragments, so we have to collect all the chunks for
+        a frame.
+
+        Parameters:
+            timeout: how many seconds to wait before giving up.
+        """
+        loop = self.loop
+        chunks = []
+        flags = 0
+
+        sock_fd = loop.run_in_executor(None, self.curl.getinfo, CurlInfo.ACTIVESOCKET)
+        if sock_fd == CURL_SOCKET_BAD:
+            raise WebSocketError("Invalid active socket", CurlECode.NO_CONNECTION_AVAILABLE)
+        while True:
+            try:
+                rlist = await aselect(sock_fd, loop=loop, timeout=timeout)
+                if rlist:
+                    chunk, frame = await self.recv_fragment(timeout=timeout)
+                    flags = frame.flags
+                    chunks.append(chunk)
+                    if frame.bytesleft == 0 and flags & CurlWsFlag.CONT == 0:
+                        break
+            except CurlError as e:
+                if e.code == CurlECode.AGAIN:
+                    pass
+                else:
+                    raise
+
+        return b"".join(chunks), flags
+
+    async def recv_str(self, *, timeout: Optional[float] = None) -> str:
+        """Receive a text frame.
+
+        Parameters:
+            timeout: how many seconds to wait before giving up.
+        """
+        data, flags = await self.recv(timeout=timeout)
+        if not flags & CurlWsFlag.TEXT:
+            raise TypeError("Received non-text frame")
+        return data.decode()
+
+    async def recv_json(self, *, loads: Callable[[str], T] = loads, timeout: Optional[float] = None) -> T:
+        """Receive a JSON frame.
+
+        Parameters:
+            loads: JSON decoder, default is json.loads.
+            timeout: how many seconds to wait before giving up.
+        """
+        data = await self.recv_str(timeout=timeout)
+        return loads(data)
+
+    async def send(self, payload: Union[str, bytes], flags: CurlWsFlag = CurlWsFlag.BINARY):
+        """Send a data frame.
+
+        Parameters:
+            payload: data to send.
+            flags: flags for the frame.
+        """
+        if self.closed:
+            raise TypeError("WebSocket is closed")
+
+        # curl expects bytes
+        if isinstance(payload, str):
+            payload = payload.encode()
+
+        # TODO: Why does concurrently sending fail
+        async with self._send_lock:
+            return await self.loop.run_in_executor(None, self.curl.ws_send, payload, flags)
+
+    async def send_binary(self, payload: bytes):
+        """Send a binary frame.
+
+        Parameters:
+            payload: binary data to send.
+        """
+        return await self.send(payload, CurlWsFlag.BINARY)
+
+    async def send_bytes(self, payload: bytes):
+        """Send a binary frame. Same as :meth:`send_binary`.
+
+        Parameters:
+            payload: binary data to send.
+        """
+        return await self.send(payload, CurlWsFlag.BINARY)
+
+    async def send_str(self, payload: str):
+        """Send a text frame.
+
+        Parameters:
+            payload: text data to send.
+        """
+        return await self.send(payload, CurlWsFlag.TEXT)
+
+    async def send_json(self, payload: Any, *, dumps: Callable[[Any], str] = dumps):
+        """Send a JSON frame.
+
+        Parameters:
+            payload: data to send.
+            dumps: JSON encoder, default is json.dumps.
+        """
+        return await self.send_str(dumps(payload))
+
+    async def ping(self, payload: Union[str, bytes]):
+        """Send a ping frame.
+
+        Parameters:
+            payload: data to send.
+        """
+        return await self.send(payload, CurlWsFlag.PING)
+
+    async def close(self, code: int = WsCloseCode.OK, message: bytes = b""):
+        """Close the connection.
+
+        Parameters:
+            code: close code.
+            message: close reason.
+        """
+        if self.curl is not_set:
+            return
+
+        # TODO: As per spec, we should wait for the server to close the connection
+        # But this is not a requirement
+        msg = self._pack_close_frame(code, message)
+        await self.send(msg, CurlWsFlag.CLOSE)
+        # The only way to close the connection appears to be curl_easy_cleanup
+        self.terminate()
+
+    def terminate(self):
+        """Terminate the underlying connection."""
+        super().terminate()
+        if not self.session._closed:
+            # WebSocket curls CANNOT be reused
+            self.session.push_curl(None)

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -381,7 +381,7 @@ class WebSocket(BaseWebSocket):
             flags: flags for the frame.
         """
         if self.closed:
-            raise TypeError("WebSocket is closed")
+            raise SessionClosed("WebSocket is closed")
 
         # curl expects bytes
         if isinstance(payload, str):
@@ -525,7 +525,7 @@ class AsyncWebSocket(BaseWebSocket):
 
     async def __aiter__(self) -> Self:
         if self.closed:
-            raise TypeError("WebSocket is closed")
+            raise SessionClosed("WebSocket is closed")
         return self
 
     async def __anext__(self) -> bytes:
@@ -541,7 +541,7 @@ class AsyncWebSocket(BaseWebSocket):
             timeout: how many seconds to wait before giving up.
         """
         if self.closed:
-            raise TypeError("WebSocket is closed")
+            raise SessionClosed("WebSocket is closed")
         if self._recv_lock.locked():
             raise TypeError("Concurrent call to recv_fragment() is not allowed")
 
@@ -551,7 +551,7 @@ class AsyncWebSocket(BaseWebSocket):
             )
             if frame.flags & CurlWsFlag.CLOSE:
                 try:
-                    self._close_code, self._close_reason = self._unpack_close_frame(chunk)
+                    code, message = self._close_code, self._close_reason = self._unpack_close_frame(chunk)
                 except WebSocketError as e:
                     # Follow the spec to close the connection
                     # Errors do not respect autoclose
@@ -559,7 +559,7 @@ class AsyncWebSocket(BaseWebSocket):
                     await self.close(e.code)
                     raise
                 if self.autoclose:
-                    await self.close()
+                    await self.close(code, message.encode())
 
         return chunk, frame
 
@@ -628,7 +628,7 @@ class AsyncWebSocket(BaseWebSocket):
             flags: flags for the frame.
         """
         if self.closed:
-            raise TypeError("WebSocket is closed")
+            raise SessionClosed("WebSocket is closed")
 
         # curl expects bytes
         if isinstance(payload, str):

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -577,7 +577,7 @@ class AsyncWebSocket(BaseWebSocket):
         chunks = []
         flags = 0
 
-        sock_fd = loop.run_in_executor(None, self.curl.getinfo, CurlInfo.ACTIVESOCKET)
+        sock_fd = await loop.run_in_executor(None, self.curl.getinfo, CurlInfo.ACTIVESOCKET)
         if sock_fd == CURL_SOCKET_BAD:
             raise WebSocketError("Invalid active socket", CurlECode.NO_CONNECTION_AVAILABLE)
         while True:

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -5,10 +5,21 @@ from select import select
 import struct
 from enum import IntEnum
 from json import loads, dumps
-from typing import Any, Callable, Dict, Final, List, Literal, Optional, Tuple, TYPE_CHECKING, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
 
 from .options import set_curl_options
-from .._wrapper import ffi, lib
 from ..aio import CURL_SOCKET_BAD
 from ..const import CurlECode, CurlOpt, CurlWsFlag, CurlInfo
 from ..curl import Curl, CurlError
@@ -32,6 +43,7 @@ if TYPE_CHECKING:
     ON_CLOSE_T = Callable[["WebSocket", int, str], None]
 
 not_set: Final[Any] = object()
+
 
 class WsCloseCode(IntEnum):
     OK = 1000
@@ -533,7 +545,9 @@ class AsyncWebSocket(BaseWebSocket):
             raise TypeError("Concurrent call to recv_fragment() is not allowed")
 
         async with self._recv_lock:
-            chunk, frame = await asyncio.wait_for(self.loop.run_in_executor(None, self.curl.ws_recv), timeout)
+            chunk, frame = await asyncio.wait_for(
+                self.loop.run_in_executor(None, self.curl.ws_recv), timeout
+            )
             if frame.flags & CurlWsFlag.CLOSE:
                 try:
                     self._close_code, self._close_reason = self._unpack_close_frame(chunk)
@@ -593,7 +607,9 @@ class AsyncWebSocket(BaseWebSocket):
             raise TypeError("Received non-text frame")
         return data.decode()
 
-    async def recv_json(self, *, loads: Callable[[str], T] = loads, timeout: Optional[float] = None) -> T:
+    async def recv_json(
+        self, *, loads: Callable[[str], T] = loads, timeout: Optional[float] = None
+    ) -> T:
         """Receive a JSON frame.
 
         Parameters:

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -161,7 +161,7 @@ class WebSocket(BaseWebSocket):
         on_error: Optional[ON_ERROR_T] = None,
     ):
         """
-        Parameters:
+        Args:
             autoclose: whether to close the WebSocket after receiving a close frame.
             skip_utf8_validation: whether to skip UTF-8 validation for text frames in run_forever().
             debug: print extra curl debug info.
@@ -242,7 +242,7 @@ class WebSocket(BaseWebSocket):
         libcurl automatically handles pings and pongs.
         ref: https://curl.se/libcurl/c/libcurl-ws.html
 
-        Parameters:
+        Args:
             url: url for the requests.
             params: query string for the requests.
             headers: headers to send.
@@ -339,7 +339,7 @@ class WebSocket(BaseWebSocket):
         """
         Receive a frame as bytes.
 
-        libcurl split frames into fragments, so we have to collect all the chunks for
+        libcurl splits frames into fragments, so we have to collect all the chunks for
         a frame.
         """
         chunks = []
@@ -375,7 +375,7 @@ class WebSocket(BaseWebSocket):
     def recv_json(self, *, loads: Callable[[str], T] = loads) -> T:
         """Receive a JSON frame.
 
-        Parameters:
+        args:
             loads: JSON decoder, default is json.loads.
         """
         data = self.recv_str()
@@ -384,7 +384,7 @@ class WebSocket(BaseWebSocket):
     def send(self, payload: Union[str, bytes], flags: CurlWsFlag = CurlWsFlag.BINARY):
         """Send a data frame.
 
-        Parameters:
+        Args:
             payload: data to send.
             flags: flags for the frame.
         """
@@ -399,7 +399,7 @@ class WebSocket(BaseWebSocket):
     def send_binary(self, payload: bytes):
         """Send a binary frame.
 
-        Parameters:
+        Args:
             payload: binary data to send.
         """
         return self.send(payload, CurlWsFlag.BINARY)
@@ -407,7 +407,7 @@ class WebSocket(BaseWebSocket):
     def send_bytes(self, payload: bytes):
         """Send a binary frame. Same as :meth:`send_binary`.
 
-        Parameters:
+        Args:
             payload: binary data to send.
         """
         return self.send(payload, CurlWsFlag.BINARY)
@@ -415,7 +415,7 @@ class WebSocket(BaseWebSocket):
     def send_str(self, payload: str):
         """Send a text frame.
 
-        Parameters:
+        Args:
             payload: text data to send.
         """
         return self.send(payload, CurlWsFlag.TEXT)
@@ -423,7 +423,7 @@ class WebSocket(BaseWebSocket):
     def send_json(self, payload: Any, *, dumps: Callable[[Any], str] = dumps):
         """Send a JSON frame.
 
-        Parameters:
+        Args:
             payload: data to send.
             dumps: JSON encoder, default is json.dumps.
         """
@@ -432,7 +432,7 @@ class WebSocket(BaseWebSocket):
     def ping(self, payload: Union[str, bytes]):
         """Send a ping frame.
 
-        Parameters:
+        Args:
             payload: data to send.
         """
         return self.send(payload, CurlWsFlag.PING)
@@ -497,7 +497,7 @@ class WebSocket(BaseWebSocket):
     def close(self, code: int = WsCloseCode.OK, message: bytes = b""):
         """Close the connection.
 
-        Parameters:
+        Args:
             code: close code.
             message: close reason.
         """
@@ -542,7 +542,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def recv_fragment(self, *, timeout: Optional[float] = None) -> Tuple[bytes, CurlWsFrame]:
         """Receive a single frame as bytes.
 
-        Parameters:
+        Args:
             timeout: how many seconds to wait before giving up.
         """
         if self.closed:
@@ -559,7 +559,9 @@ class AsyncWebSocket(BaseWebSocket):
                 raise WebSocketTimeout("WebSocket recv_fragment() timed out")
             if frame.flags & CurlWsFlag.CLOSE:
                 try:
-                    code, message = self._close_code, self._close_reason = self._unpack_close_frame(chunk)
+                    code, message = self._close_code, self._close_reason = self._unpack_close_frame(
+                        chunk
+                    )
                 except WebSocketError as e:
                     # Follow the spec to close the connection
                     # Errors do not respect autoclose
@@ -575,10 +577,10 @@ class AsyncWebSocket(BaseWebSocket):
         """
         Receive a frame as bytes.
 
-        libcurl split frames into fragments, so we have to collect all the chunks for
+        libcurl splits frames into fragments, so we have to collect all the chunks for
         a frame.
 
-        Parameters:
+        Args:
             timeout: how many seconds to wait before giving up.
         """
         loop = self.loop
@@ -608,7 +610,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def recv_str(self, *, timeout: Optional[float] = None) -> str:
         """Receive a text frame.
 
-        Parameters:
+        Args:
             timeout: how many seconds to wait before giving up.
         """
         data, flags = await self.recv(timeout=timeout)
@@ -621,7 +623,7 @@ class AsyncWebSocket(BaseWebSocket):
     ) -> T:
         """Receive a JSON frame.
 
-        Parameters:
+        Args:
             loads: JSON decoder, default is json.loads.
             timeout: how many seconds to wait before giving up.
         """
@@ -631,7 +633,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def send(self, payload: Union[str, bytes], flags: CurlWsFlag = CurlWsFlag.BINARY):
         """Send a data frame.
 
-        Parameters:
+        Args:
             payload: data to send.
             flags: flags for the frame.
         """
@@ -649,7 +651,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def send_binary(self, payload: bytes):
         """Send a binary frame.
 
-        Parameters:
+        Args:
             payload: binary data to send.
         """
         return await self.send(payload, CurlWsFlag.BINARY)
@@ -657,7 +659,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def send_bytes(self, payload: bytes):
         """Send a binary frame. Same as :meth:`send_binary`.
 
-        Parameters:
+        Args:
             payload: binary data to send.
         """
         return await self.send(payload, CurlWsFlag.BINARY)
@@ -665,7 +667,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def send_str(self, payload: str):
         """Send a text frame.
 
-        Parameters:
+        Args:
             payload: text data to send.
         """
         return await self.send(payload, CurlWsFlag.TEXT)
@@ -673,7 +675,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def send_json(self, payload: Any, *, dumps: Callable[[Any], str] = dumps):
         """Send a JSON frame.
 
-        Parameters:
+        Args:
             payload: data to send.
             dumps: JSON encoder, default is json.dumps.
         """
@@ -682,7 +684,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def ping(self, payload: Union[str, bytes]):
         """Send a ping frame.
 
-        Parameters:
+        Args:
             payload: data to send.
         """
         return await self.send(payload, CurlWsFlag.PING)
@@ -690,7 +692,7 @@ class AsyncWebSocket(BaseWebSocket):
     async def close(self, code: int = WsCloseCode.OK, message: bytes = b""):
         """Close the connection.
 
-        Parameters:
+        Args:
             code: close code.
             message: close reason.
         """

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -306,6 +306,7 @@ class WebSocket(BaseWebSocket):
         # https://curl.se/docs/websocket.html
         curl.setopt(CurlOpt.CONNECT_ONLY, 2)
         curl.perform()
+        return self
 
     def recv_fragment(self) -> Tuple[bytes, CurlWsFrame]:
         """Receive a single frame as bytes."""

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,7 @@ Curl
    .. automethod:: close
    .. automethod:: ws_recv
    .. automethod:: ws_send
+   .. automethod:: ws_close
 
 AsyncCurl
 ~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,7 +24,6 @@ Curl
    .. automethod:: close
    .. automethod:: ws_recv
    .. automethod:: ws_send
-   .. automethod:: ws_close
 
 AsyncCurl
 ~~~~~~
@@ -146,10 +145,31 @@ Request, Response and WebSocket
 .. autoclass:: curl_cffi.requests.WebSocket
 
    .. automethod:: __init__
+   .. automethod:: connect
+   .. automethod:: recv_fragment
    .. automethod:: recv
+   .. automethod:: recv_str
+   .. automethod:: recv_json
    .. automethod:: send
+   .. automethod:: send_binary
+   .. automethod:: send_bytes
+   .. automethod:: send_str
+   .. automethod:: send_json
+   .. automethod:: ping
    .. automethod:: run_forever
    .. automethod:: close
-   .. automethod:: arecv
-   .. automethod:: asend
 
+.. autoclass:: curl_cffi.requests.AsyncWebSocket
+
+   .. automethod:: __init__
+   .. automethod:: recv_fragment
+   .. automethod:: recv
+   .. automethod:: recv_str
+   .. automethod:: recv_json
+   .. automethod:: send
+   .. automethod:: send_binary
+   .. automethod:: send_bytes
+   .. automethod:: send_str
+   .. automethod:: send_json
+   .. automethod:: ping
+   .. automethod:: close

--- a/examples/custom_response_class.py
+++ b/examples/custom_response_class.py
@@ -2,6 +2,7 @@ from curl_cffi import requests
 from curl_cffi.curl import Curl, CurlInfo
 from typing import cast
 
+
 class CustomResponse(requests.Response):
     def __init__(self, curl: Curl | None = None, request: requests.Request | None = None):
         super().__init__(curl, request)
@@ -11,10 +12,11 @@ class CustomResponse(requests.Response):
     @property
     def status(self):
         return self.status_code
-    
+
     def custom_method(self):
         return "this is a custom method"
-    
+
+
 session = requests.Session(response_class=CustomResponse)
 response: CustomResponse = session.get("http://example.com")
 print(f"{response.status=}")

--- a/examples/websockets/long_running.py
+++ b/examples/websockets/long_running.py
@@ -3,7 +3,7 @@ from curl_cffi.requests import Session, WebSocket
 msg_count = 0
 
 
-def on_message(ws: WebSocket, message):
+def on_message(ws: WebSocket, message: str | bytes):
     global msg_count
 
     print("------------------------------------------------------")
@@ -15,7 +15,7 @@ def on_message(ws: WebSocket, message):
         ws.close()
 
 
-def on_error(ws: WebSocket, error):
+def on_error(ws: WebSocket, error: Exception):
     print(error)
 
 
@@ -27,16 +27,14 @@ def on_open(ws: WebSocket):
     print(">>> Websocket open!")
 
 
-def on_close(ws: WebSocket):
-    print("<<< Websocket closed!")
+def on_close(ws: WebSocket, code: int, reason: str):
+    print(f"<<< Websocket closed! code: {code}, reason: {reason}, clean: {code in (1000, 1001)}")
 
 
-with Session() as s:
-    ws = s.ws_connect(
-        "wss://api.gemini.com/v1/marketdata/BTCUSD",
-        on_open=on_open,
-        on_close=on_close,
-        on_message=on_message,
-        on_error=on_error,
-    )
-    ws.run_forever()
+ws = WebSocket(
+    on_open=on_open,
+    on_close=on_close,
+    on_message=on_message,
+    on_error=on_error,
+)
+ws.run_forever("wss://api.gemini.com/v1/marketdata/BTCUSD")

--- a/examples/websockets/long_running.py
+++ b/examples/websockets/long_running.py
@@ -1,4 +1,4 @@
-from curl_cffi.requests import Session, WebSocket
+from curl_cffi.requests import WebSocket
 
 msg_count = 0
 

--- a/examples/websockets/long_running_async.py
+++ b/examples/websockets/long_running_async.py
@@ -1,42 +1,23 @@
-"""
-WIP: this has not been implemented yet.
-"""
-
 import asyncio
 
 from curl_cffi import requests
 
 
-async def on_message(ws, message):
-    print(message)
-
-
-async def on_error(ws, error):
-    print(error)
-
-
-async def on_open(ws):
-    print(
-        "For websockets, you need to set $wss_proxy environment variable!\n"
-        "$https_proxy will not work!"
-    )
-    print(">>> Websocket open!")
-
-
-async def on_close(ws):
-    print("<<< Websocket closed!")
-
-
 async def main():
     async with requests.AsyncSession() as s:
-        ws = await s.ws_connect(
-            "wss://api.gemini.com/v1/marketdata/BTCUSD",
-            on_open=on_open,
-            on_close=on_close,
-            on_message=on_message,
-            on_error=on_error,
+        ws = await s.ws_connect("wss://api.gemini.com/v1/marketdata/BTCUSD")
+        print(
+            "For websockets, you need to set $wss_proxy environment variable!\n"
+            "$https_proxy will not work!"
         )
-        ws.run_forever()
+        print(">>> Websocket open!")
+
+        async for message in ws:
+            print(message)
+            if ws.closed:
+                break
+
+        print("<<< Websocket closed!")
 
 
 asyncio.run(main())

--- a/examples/websockets/long_running_async.py
+++ b/examples/websockets/long_running_async.py
@@ -14,8 +14,6 @@ async def main():
 
         async for message in ws:
             print(message)
-            if ws.closed:
-                break
 
         print("<<< Websocket closed!")
 

--- a/examples/websockets/short_running.py
+++ b/examples/websockets/short_running.py
@@ -4,18 +4,18 @@ from curl_cffi import requests
 
 URL = "ws://echo.websocket.events"
 
-with requests.Session() as s:
-    w = s.ws_connect(URL)
-    w.send(b"Foo")
-    reply = w.recv()
-    print(reply)
+
+ws = requests.WebSocket().connect(URL)
+ws.send(b"Foo")
+reply = ws.recv()
+print(reply)
 
 
 async def async_examples():
     async with requests.AsyncSession() as s:
-        w = await s.ws_connect(URL)
-        await w.asend(b"Bar")
-        reply = await w.arecv()
+        ws = await s.ws_connect(URL)
+        await ws.send(b"Bar")
+        reply = await ws.recv()
         print(reply)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "curl_cffi"
-version = "0.8.0b7"
+version = "0.8.1b1"
 authors = [{ name = "Lyonnet", email = "infinitesheldon@gmail.com" }]
 description = "libcurl ffi bindings for Python, with impersonation support."
 license = { file = "LICENSE" }

--- a/tests/integration/test_response_class.py
+++ b/tests/integration/test_response_class.py
@@ -1,16 +1,19 @@
 import pytest
 from curl_cffi import requests
 
+
 def test_default_response():
     response = requests.get("http://example.com")
     assert type(response) == requests.Response
     print(response.status_code)
 
+
 class CustomResponse(requests.Response):
     @property
     def status(self):
         return self.status_code
-    
+
+
 def test_custom_response():
     session = requests.Session(response_class=CustomResponse)
     response = session.get("http://example.com")
@@ -18,7 +21,10 @@ def test_custom_response():
     assert hasattr(response, "status")
     print(response.status)
 
-class WrongTypeResponse: pass
+
+class WrongTypeResponse:
+    pass
+
 
 def test_wrong_type_custom_response():
     with pytest.raises(TypeError):

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -594,7 +594,9 @@ class TestServer(Server):
 
 async def echo(websocket):
     while True:
-        name = (await websocket.recv()).decode()
+        name = await websocket.recv()
+        if isinstance(name, bytes):
+            name = name.decode()
         # print(f"<<< {name}")
 
         await websocket.send(name)

--- a/tests/unittest/test_headers.py
+++ b/tests/unittest/test_headers.py
@@ -1,5 +1,5 @@
 from curl_cffi.requests import Headers
-from curl_cffi.requests.options import update_header_line
+from curl_cffi.requests.utils import update_header_line
 
 
 def test_headers():

--- a/tests/unittest/test_headers.py
+++ b/tests/unittest/test_headers.py
@@ -1,5 +1,5 @@
 from curl_cffi.requests import Headers
-from curl_cffi.requests.session import _update_header_line
+from curl_cffi.requests.options import update_header_line
 
 
 def test_headers():
@@ -26,11 +26,11 @@ def test_header_output():
 
 def test_replace_header():
     header_lines = []
-    _update_header_line(header_lines, "content-type", "image/png")
+    update_header_line(header_lines, "content-type", "image/png")
     assert header_lines == ["content-type: image/png"]
-    _update_header_line(header_lines, "Content-Type", "application/json")
+    update_header_line(header_lines, "Content-Type", "application/json")
     assert header_lines == ["content-type: image/png"]
-    _update_header_line(header_lines, "Content-Type", "application/json", replace=True)
+    update_header_line(header_lines, "Content-Type", "application/json", replace=True)
     assert header_lines == ["Content-Type: application/json"]
-    _update_header_line(header_lines, "Host", "example.com", replace=True)
+    update_header_line(header_lines, "Host", "example.com", replace=True)
     assert header_lines == ["Content-Type: application/json", "Host: example.com"]

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -10,7 +10,6 @@ from curl_cffi import CurlOpt, requests
 from curl_cffi.const import CurlECode, CurlInfo
 from curl_cffi.requests.errors import SessionClosed
 from curl_cffi.requests.models import Response
-from curl_cffi.requests.session import _update_url_params
 
 
 def test_head(server):

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -649,9 +649,6 @@ def test_closed_session_throws_error():
     with pytest.raises(SessionClosed):
         s.patch("https://example.com")
 
-    with pytest.raises(SessionClosed):
-        s.ws_connect("wss://example.com")
-
 
 def test_stream_iter_content(server):
     with requests.Session() as s:

--- a/tests/unittest/test_websockets.py
+++ b/tests/unittest/test_websockets.py
@@ -1,27 +1,40 @@
-from curl_cffi.requests import Session
+from curl_cffi.requests import AsyncSession, WebSocket
 
 
 def test_websocket(ws_server):
-    with Session() as s:
-        s.ws_connect(ws_server.url)
+    ws = WebSocket()
+    ws.connect(ws_server.url)
 
 
 def test_hello(ws_server):
-    with Session() as s:
-        ws = s.ws_connect(ws_server.url)
-        ws.send(b"Foo me once")
-        content, _ = ws.recv()
-        assert content == b"Foo me once"
+    ws = WebSocket()
+    ws.connect(ws_server.url)
+    ws.send(b"Foo me once")
+    content, _ = ws.recv()
+    assert content == b"Foo me once"
 
 
 def test_hello_twice(ws_server):
-    with Session() as s:
-        w = s.ws_connect(ws_server.url)
+    ws = WebSocket()
+    ws.connect(ws_server.url)
 
-        w.send(b"Bar")
-        reply, _ = w.recv()
+    ws.send(b"Bar")
+    reply, _ = ws.recv()
+
+    for _ in range(10):
+        ws.send_str("Bar")
+        reply = ws.recv_str()
+        assert reply == "Bar"
+
+
+async def test_hello_twice_async(ws_server):
+    async with AsyncSession() as s:
+        ws = await s.ws_connect(ws_server.url)
+
+        await ws.send(b"Bar")
+        reply, _ = await ws.recv()
 
         for _ in range(10):
-            w.send(b"Bar")
-            reply, _ = w.recv()
-            assert reply == b"Bar"
+            await ws.send_str("Bar")
+            reply = await ws.recv_str()
+            assert reply == "Bar"

--- a/tests/unittest/test_websockets.py
+++ b/tests/unittest/test_websockets.py
@@ -1,9 +1,13 @@
-from curl_cffi.requests import AsyncSession, WebSocket
+from curl_cffi.requests import AsyncSession, WebSocket, Session
 
 
 def test_websocket(ws_server):
     ws = WebSocket()
     ws.connect(ws_server.url)
+
+    # deprecated
+    with Session() as s:
+        s.ws_connect(ws_server.url)
 
 
 def test_hello(ws_server):
@@ -12,6 +16,13 @@ def test_hello(ws_server):
     ws.send(b"Foo me once")
     content, _ = ws.recv()
     assert content == b"Foo me once"
+
+    # deprecated
+    with Session() as s:
+        ws = s.ws_connect(ws_server.url)
+        ws.send(b"Foo me once")
+        content, _ = ws.recv()
+        assert content == b"Foo me once"
 
 
 def test_hello_twice(ws_server):
@@ -25,6 +36,12 @@ def test_hello_twice(ws_server):
         ws.send_str("Bar")
         reply = ws.recv_str()
         assert reply == "Bar"
+
+    with Session() as s:
+        ws = s.ws_connect(ws_server.url)
+        ws.send(b"Foo me once")
+        content, _ = ws.recv()
+        assert content == b"Foo me once"
 
 
 async def test_hello_twice_async(ws_server):


### PR DESCRIPTION
This is a continuation of #206, which went stale after I got quite busy. Addresses #202 WebSocket requests (fixes #202, fixes #270).

- Separates async support into AsyncWebSocket
- Removes Session.ws_connect() and allows initialization via WebSocket() constructor directly
    + This is because WebSockets need their own curl handle, as making a request will break the `CurlOpt.CONNECT_ONLY` value, so the session becomes useless if a WebSocket is created from it
    + This is not an issue with AsyncSession.connect() as it already maintains multiple curl handles, though a curl handle is unusable after a WebSocket uses it anyway
- Changes WebSocket API to more closely match websockets
- Changes AsyncWebSocket API to more closely match aiohttp
    + Removes sync-style callback handlers
    + Adds send/recv_str/json helper methods
- Adds on_data callback to WebSocket
- Adds autoclose and skip_utf8_validation parameters, and close_code and close_reason attributes
- Adds iteration support