### PR TITLE
Fixed a typo, changed timeout_ms cancellation time to be < 0

### DIFF
--- a/curl_cffi/aio.py
+++ b/curl_cffi/aio.py
@@ -85,8 +85,8 @@ def timer_function(curlm, timeout_ms: int, clientp: "AsyncCurl"):
     """
     async_curl = ffi.from_handle(clientp)
 
-    # A timeout_ms value of -1 means you should delete the timer.
-    if timeout_ms == -1:
+    # A timeout_ms value <= 0 means you should delete the timer.
+    if timeout_ms <= 0:
         for timer in async_curl._timers:
             timer.cancel()
         async_curl._timers = WeakSet()
@@ -205,7 +205,7 @@ class AsyncCurl:
         """Call curl_multi_info_read to read data for given socket."""
         if not self._curlm:
             warnings.warn(
-                "Curlm alread closed! quitting from process_data", CurlCffiWarning, stacklevel=2
+                "Curlm already closed! quitting from process_data", CurlCffiWarning, stacklevel=2
             )
             return
 

--- a/curl_cffi/aio.py
+++ b/curl_cffi/aio.py
@@ -85,8 +85,8 @@ def timer_function(curlm, timeout_ms: int, clientp: "AsyncCurl"):
     """
     async_curl = ffi.from_handle(clientp)
 
-    # A timeout_ms value <= 0 means you should delete the timer.
-    if timeout_ms <= 0:
+    # A timeout_ms value < 0 means you should delete the timer.
+    if timeout_ms < 0:
         for timer in async_curl._timers:
             timer.cancel()
         async_curl._timers = WeakSet()


### PR DESCRIPTION
修复拼写错误，更改timer_function中取消计时器的条件为小于零。
更改为小于零-1还可以正常使用，而且若timeout是-1一之外的负数，程序不会报错。
Fixed a typo, changed timeout_ms cancellation time to be < 0.
-1 can still be used normally, and if timeout is a negative number is -1, the program will not throw an exception.
