### PR TITLE
Better typing (response class and issue with `.get`, `.post`, ...)

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -21,6 +21,7 @@ from typing import (
     Union,
     cast,
     Generic,
+    TypeVar
 )
 from urllib.parse import urlparse
 
@@ -43,15 +44,9 @@ with suppress(ImportError):
     import eventlet.tpool
 
 if sys.version_info >= (3, 12):
-    from typing import TypeVar
     R = TypeVar('R', bound=Response, default=Response)
 else:
-    try:
-        from typing_extensions import TypeVar
-        R = TypeVar('R', bound=Response, default=Response)
-    except ImportError:
-        from typing import TypeVar
-        R = TypeVar('R', bound=Response)
+    R = TypeVar('R', bound=Response)
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -226,7 +226,7 @@ class BaseSession(Generic[R]):
 
     def _parse_response(self, curl, buffer, header_buffer, default_encoding) -> R:
         c = curl
-        rsp = self.response_class(c)
+        rsp = cast(R, self.response_class(c))
         rsp.url = cast(bytes, c.getinfo(CurlInfo.EFFECTIVE_URL)).decode()
         if buffer:
             rsp.content = buffer.getvalue()
@@ -848,7 +848,7 @@ class AsyncSession(BaseSession[R]):
         curl.setopt(CurlOpt.CONNECT_ONLY, 2)  # https://curl.se/docs/websocket.html
 
         await self.loop.run_in_executor(None, curl.perform)
-        return AsyncWebSocket(self[R], curl, autoclose=autoclose)
+        return AsyncWebSocket(cast(AsyncSession[R], self), curl, autoclose=autoclose)
 
     async def request(
         self,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -42,14 +42,15 @@ with suppress(ImportError):
 with suppress(ImportError):
     import eventlet.tpool
 
-try:
-    from typing_extensions import TypeVar
-    R = TypeVar('R', bound=Response, default=Response)
-except ImportError:
+if sys.version_info >= (3, 12):
     from typing import TypeVar
-    if sys.version >= (3, 12):
+    R = TypeVar('R', bound=Response, default=Response)
+else:
+    try:
+        from typing_extensions import TypeVar
         R = TypeVar('R', bound=Response, default=Response)
-    else:
+    except ImportError:
+        from typing import TypeVar
         R = TypeVar('R', bound=Response)
 
 if TYPE_CHECKING:

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -44,13 +44,13 @@ with suppress(ImportError):
 
 try:
     from typing_extensions import TypeVar
+    R = TypeVar('R', bound=Response, default=Response)
 except ImportError:
     from typing import TypeVar
-    
-if sys.version >= (3, 12):
-    R = TypeVar('R', bound=Response, default=Response)
-else:
-    R = TypeVar('R', bound=Response)
+    if sys.version >= (3, 12):
+        R = TypeVar('R', bound=Response, default=Response)
+    else:
+        R = TypeVar('R', bound=Response)
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -848,7 +848,11 @@ class AsyncSession(BaseSession[R]):
         curl.setopt(CurlOpt.CONNECT_ONLY, 2)  # https://curl.se/docs/websocket.html
 
         await self.loop.run_in_executor(None, curl.perform)
-        return AsyncWebSocket(cast(AsyncSession[R], self), curl, autoclose=autoclose)
+        return AsyncWebSocket(
+            cast(AsyncSession[Response], self),
+            curl,
+            autoclose=autoclose,
+        )
 
     async def request(
         self,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import asyncio
 import queue
 import threading
@@ -19,8 +20,8 @@ from typing import (
     TypedDict,
     Union,
     cast,
+    Generic,
 )
-from typing_extensions import TypeVar, Generic
 from urllib.parse import urlparse
 
 from ..aio import AsyncCurl
@@ -41,7 +42,15 @@ with suppress(ImportError):
 with suppress(ImportError):
     import eventlet.tpool
 
-R = TypeVar('R', bound=Response, default=Response)
+try:
+    from typing_extensions import TypeVar
+except ImportError:
+    from typing import TypeVar
+    
+if sys.version >= (3, 12):
+    R = TypeVar('R', bound=Response, default=Response)
+else:
+    R = TypeVar('R', bound=Response)
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack


### PR DESCRIPTION
This PR includes two things:
- In my previous PR to make the methods `.get`, `.post`, `.put`, ..., I forgot to add `total=False` in the `TypedDict` they were unpacking, which was getting the type hint to say `Any`.
  - Before: 
    <img width="520" alt="Capture d’écran 2025-01-27 à 22 18 09" src="https://github.com/user-attachments/assets/703f3a6e-e05f-4ad0-bcb9-af7ee7e13a72" />
  - After: 
    <img width="520" alt="Capture d’écran 2025-01-27 à 22 18 57" src="https://github.com/user-attachments/assets/59e0f89b-c02d-45cf-ad22-0df484fe92ce" />

- A type hint for the response class. The results of requests were always an object `Response`, even if the `response_class` was changed. Now, if the `response_class` argument is set, the result hint will be an instance of this argument. Here is what it does:
  <img width="520" alt="Capture d’écran 2025-01-27 à 22 19 34" src="https://github.com/user-attachments/assets/307bfabc-1446-442f-bb98-34ba24ce1e8a" />
