### PR TITLE
A Fix for the issue #487 and #495

### DIFF
--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -5,7 +5,6 @@ import struct
 from enum import IntEnum
 from functools import partial
 from json import dumps, loads
-from select import select
 import time
 from typing import (
     TYPE_CHECKING,


### PR DESCRIPTION
Earlier, when the message size was > default 1024, the code chunked it without maintaining the order so now it waits for the entire message to come and then sends it further.
And due to the `select` function, it hanged which have been turned into a timer which checks the incoming message time and if it exceeds the delta then invokes a timeout.