### PR TITLE
fix: mark the optional params in SessionRequestParams as optional

### DIFF
--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -57,7 +57,7 @@ from .websockets import (
 
 if TYPE_CHECKING:
 
-    class SessionRequestParams(RequestParams):
+    class SessionRequestParams(RequestParams, total=False):
         thread: Optional[ThreadType]
         curl_options: Optional[dict]
         debug: Optional[bool]


### PR DESCRIPTION
This PR fixes an issue where both Pyright and Basedpyright report missing arguments if the optional parameters in `SessionRequestParams` are not supplied.

**Issue:** _Arguments missing for parameters "thread", "curl_options", "debug" Pyright (reportCallIssue)_

**Solution:** Specifying `total=False` in the definition of `SessionRequestParams` correctly marks these keys as optional.

Locally verified that this resolves the issue reported by both static type checkers.