### PR TITLE
Add primary and local ports to response

### DIFF
--- a/curl_cffi/requests/cookies.py
+++ b/curl_cffi/requests/cookies.py
@@ -10,7 +10,8 @@ import warnings
 from dataclasses import dataclass
 from http.cookiejar import Cookie, CookieJar
 from http.cookies import _unquote
-from typing import Iterator, MutableMapping, Optional, Union
+from typing import Optional, Union
+from collections.abc import Iterator, MutableMapping
 from urllib.parse import urlparse
 
 from ..utils import CurlCffiWarning

--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -2,7 +2,8 @@ import queue
 import re
 import warnings
 from concurrent.futures import Future
-from typing import Any, Awaitable, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
+from collections.abc import Awaitable
 
 from ..curl import Curl
 from ..utils import CurlCffiWarning
@@ -51,7 +52,9 @@ class Response:
         encoding: http body encoding.
         charset: alias for encoding.
         primary_ip: primary ip of the server.
+        primary_port: primary port of the server.
         local_ip: local ip used in this connection.
+        local_port: local port used in this connection.
         charset_encoding: encoding specified by the Content-Type header.
         default_encoding: encoding for decoding response content if charset is not found in
                 headers. Defaults to "utf-8". Can be set to a callable for automatic detection.
@@ -77,7 +80,9 @@ class Response:
         self.redirect_url = ""
         self.http_version = 0
         self.primary_ip: str = ""
+        self.primary_port: int = 0
         self.local_ip: str = ""
+        self.local_port: int = 0
         self.history: list[dict[str, Any]] = []
         self.infos: dict[str, Any] = {}
         self.queue: Optional[queue.Queue] = None

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -271,7 +271,9 @@ class BaseSession(Generic[R]):
         # print("Cookies after extraction", self._cookies)
 
         rsp.primary_ip = cast(bytes, c.getinfo(CurlInfo.PRIMARY_IP)).decode()
+        rsp.primary_port = cast(int, c.getinfo(CurlInfo.PRIMARY_PORT))
         rsp.local_ip = cast(bytes, c.getinfo(CurlInfo.LOCAL_IP)).decode()
+        rsp.local_port = cast(int, c.getinfo(CurlInfo.LOCAL_PORT))
         rsp.default_encoding = default_encoding
         rsp.elapsed = cast(float, c.getinfo(CurlInfo.TOTAL_TIME))
         rsp.redirect_count = cast(int, c.getinfo(CurlInfo.REDIRECT_COUNT))

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -11,7 +11,7 @@ from curl_cffi.const import CurlECode, CurlInfo
 from curl_cffi.requests.errors import SessionClosed
 from curl_cffi.requests.exceptions import HTTPError
 from curl_cffi.requests.models import Response
-from curl_cffi.utils import CurlCffiWarning, config_warnings
+from curl_cffi.utils import CurlCffiWarning
 
 
 def test_head(server):
@@ -901,16 +901,19 @@ def test_max_recv_speed(server):
 
 
 def test_curl_infos(server):
-    s = requests.Session(curl_infos=[CurlInfo.PRIMARY_IP])
+    s = requests.Session(curl_infos=[CurlInfo.PRIMARY_IP, CurlInfo.PRIMARY_PORT])
 
     r = s.get(str(server.url))
 
     assert r.infos[CurlInfo.PRIMARY_IP] == b"127.0.0.1"  # pyright: ignore
+    assert r.infos[CurlInfo.PRIMARY_PORT] == 8000
 
 
-def test_response_ip(server):
+def test_response_ip_and_port(server):
     s = requests.Session()
     r = s.get(str(server.url))
 
     assert r.primary_ip == "127.0.0.1"
+    assert r.primary_port == 8000
     assert r.local_ip == "127.0.0.1"
+    assert r.local_port != 0


### PR DESCRIPTION
Hello! Thanks for the great library.

In some cases it's useful to have port details on response object. Primary and local IP were already attached, so I've added ports as well.

Non related changes came from formatting, not sure if I should revert them because they are out of scope or leave them 🤔 