### PR TITLE
Fix stream abort, close #471

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -18,6 +18,7 @@ except ImportError:
     from json import loads
 
 CHARSET_RE = re.compile(r"charset=([\w-]+)")
+STREAM_END = object()
 
 
 def clear_queue(q: queue.Queue):
@@ -201,9 +202,8 @@ class Response:
                 raise chunk
 
             # end of stream.
-            if chunk is None:
-                self.curl.reset()
-                return
+            if chunk is STREAM_END:
+                break
 
             yield chunk
 
@@ -270,7 +270,7 @@ class Response:
                 raise chunk
 
             # end of stream.
-            if chunk is None:
+            if chunk is STREAM_END:
                 await self.aclose()
                 return
 

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -10,25 +10,8 @@ import warnings
 from collections import Counter
 from io import BytesIO
 from json import dumps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Final,
-    Literal,
-    Optional,
-    Union,
-    cast,
-)
-from urllib.parse import (
-    ParseResult,
-    parse_qsl,
-    quote,
-    unquote,
-    urlencode,
-    urljoin,
-    urlparse,
-)
+from typing import TYPE_CHECKING, Any, Callable, Final, Literal, Optional, Union, cast
+from urllib.parse import ParseResult, parse_qsl, quote, urlencode, urljoin, urlparse
 
 from ..const import CurlHttpVersion, CurlOpt, CurlSslVersion
 from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
@@ -526,12 +509,9 @@ def set_curl_options(
         proxy = cast(Optional[str], proxies.get(parts.scheme, proxies.get("all")))
         if parts.hostname:
             proxy = (
-                cast(
-                    Optional[str],
-                    proxies.get(
-                        f"{parts.scheme}://{parts.hostname}",
-                        proxies.get(f"all://{parts.hostname}"),
-                    ),
+                proxies.get(
+                    f"{parts.scheme}://{parts.hostname}",
+                    proxies.get(f"all://{parts.hostname}"),
                 )
                 or proxy
             )


### PR DESCRIPTION
The error seems to be caused by:

https://github.com/lexiforest/curl_cffi/blob/569ca56d87395793193f2ff2ac892d1d840cd9a4/curl_cffi/requests/models.py#L199-L201

I'm not sure why I added a `reset` here, it seems to be useless.