### PR TITLE
fix: let request headers encoding take precedence over session headers encoding

### DIFF
--- a/curl_cffi/requests/headers.py
+++ b/curl_cffi/requests/headers.py
@@ -13,7 +13,6 @@ from collections.abc import (
     Sequence,
     ValuesView,
 )
-
 from typing import Any, AnyStr, Optional, Union, cast
 
 HeaderTypes = Union[
@@ -85,11 +84,13 @@ class Headers(MutableMapping[str, Optional[str]]):
     def __init__(
         self, headers: Optional[HeaderTypes] = None, encoding: Optional[str] = None
     ):
+        self._list: list[tuple[bytes, bytes, Optional[bytes]]]
+
         if isinstance(headers, Headers):
             self._list = list(headers._list)
             encoding = encoding or headers.encoding
         elif not headers:
-            self._list: list[tuple[bytes, bytes, Optional[bytes]]] = []
+            self._list = []
         elif isinstance(headers, Mapping):
             self._list = [
                 (

--- a/curl_cffi/requests/headers.py
+++ b/curl_cffi/requests/headers.py
@@ -85,11 +85,11 @@ class Headers(MutableMapping[str, Optional[str]]):
     def __init__(
         self, headers: Optional[HeaderTypes] = None, encoding: Optional[str] = None
     ):
-        if not headers:
-            self._list: list[tuple[bytes, bytes, Optional[bytes]]] = []
-        elif isinstance(headers, Headers):
+        if isinstance(headers, Headers):
             self._list = list(headers._list)
             encoding = encoding or headers.encoding
+        elif not headers:
+            self._list: list[tuple[bytes, bytes, Optional[bytes]]] = []
         elif isinstance(headers, Mapping):
             self._list = [
                 (

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -392,7 +392,9 @@ def set_curl_options(
 
     # headers
     base_headers, headers = headers_list
-    h = Headers(base_headers)
+    # let headers encoding take precedence over base headers encoding
+    encoding = headers.encoding if isinstance(headers, Headers) else None
+    h = Headers(base_headers, encoding=encoding)
     h.update(headers)
 
     # remove Host header if it's unnecessary, otherwise curl may get confused.

--- a/examples/custom_response_class.py
+++ b/examples/custom_response_class.py
@@ -5,7 +5,7 @@ from typing import cast
 
 class CustomResponse(curl_cffi.Response):
     def __init__(
-      self, curl: Curl | None = None, request: curl_cffi.Request | None = None
+        self, curl: Curl | None = None, request: curl_cffi.Request | None = None
     ):
         super().__init__(curl, request)
         self.local_port = cast(int, curl.getinfo(CurlInfo.LOCAL_PORT))

--- a/examples/impersonate.py
+++ b/examples/impersonate.py
@@ -43,7 +43,7 @@ extra_fp = {
 
 
 r = curl_cffi.get(
-  url, ja3=okhttp4_android10_ja3, akamai=okhttp4_android10_akamai, extra_fp=extra_fp
+    url, ja3=okhttp4_android10_ja3, akamai=okhttp4_android10_akamai, extra_fp=extra_fp
 )
 
 print(r.json())

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 
 import pytest
 
+from curl_cffi import Headers
 from curl_cffi.requests import AsyncSession, RequestsError
 from curl_cffi.requests.errors import SessionClosed
 
@@ -131,6 +132,14 @@ async def test_headers(server):
         )
         headers = r.json()
         assert headers["Foo"][0] == "bar"
+
+
+async def test_headers_encoding_is_preserved(server):
+    async with AsyncSession() as s:
+        r = await s.get(str(server.url), headers=Headers(encoding="utf-8"))
+        assert r.status_code == 200
+        assert r.request is not None
+        assert r.request.headers.encoding == "utf-8"
 
 
 async def test_cookies(server):

--- a/tests/unittest/test_headers.py
+++ b/tests/unittest/test_headers.py
@@ -48,6 +48,12 @@ def test_wrapped_headers_preserve_encoding():
     assert wrapped_headers.encoding == "utf-8"
 
 
+def test_wrapped_empty_headers_preserve_encoding():
+    headers = Headers({}, encoding="utf-8")
+    wrapped_headers = Headers(headers)
+    assert wrapped_headers.encoding == "utf-8"
+
+
 def test_wrapped_headers_change_encoding():
     headers = Headers({"foo": "bar"}, encoding="utf-8")
     wrapped_headers = Headers(headers, encoding="ascii")


### PR DESCRIPTION
#401 has fixed encoding preservation on the headers object itself, but still two issues were left:
1. Encoding of the "empty" headers (`Headers(encoding="utf-8")`) was not preserved as the earlier if branch covered `if not headers` condition.
2. In `set_curl_options` `base_headers` encoding (or if we talk about the session level - session headers encoding) took precedence over the encoding of the headers passed via the session's request methods.

Both problems could have been ugily fixed on the user side by instantiating the session as follows (the `cache-control` header could be replaced with any header of choice):
```python
AsyncSession(
    headers=Headers(
        headers=Headers({"cache-control": "no-cache"}),
        encoding="utf-8",
   )
) 
```
But it's far away from being a good solution.

Hope for positive feedback here!