### PR TITLE
fix HEADERFUNCTION typo

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -205,7 +205,7 @@ class Curl:
         elif option == CurlOpt.HEADERFUNCTION:
             c_value = ffi.new_handle(value)
             self._header_handle = c_value
-            lib._curl_easy_setopt(self._curl, CurlOpt.WRITEFUNCTION, lib.write_callback)
+            lib._curl_easy_setopt(self._curl, CurlOpt.HEADERFUNCTION, lib.write_callback)
             option = CurlOpt.HEADERDATA
         elif value_type == "char*":
             c_value = value.encode() if isinstance(value, str) else value


### PR DESCRIPTION
fix:
```
Fatal Python error:
b_from_handle: ffi.from_handle() detected that the address passed points to garbage. If it is really the result of ffi.new_handle(), then the Python object has already been garbage collected
Python runtime state: initialized
```