### PR TITLE
Response hint fix for < 3.13

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -43,7 +43,7 @@ with suppress(ImportError):
 if sys.version_info >= (3, 13):
     R = TypeVar("R", bound=Response, default=Response)
 else:
-    R = TypeVar("R", bound=Response)
+    R = Response
 
 if TYPE_CHECKING:
     from typing_extensions import Unpack


### PR DESCRIPTION
On my PR #490 I was initially using typing_extension for the custom response class on version lower than 3.13. But I didn't check again after removing it. So now for all version under 3.13, it shows Any as the default response object. I guess fewer people use the `response_class` option, so it's better if the other majority get their correct type hint.