### PR TITLE
Fix websocket close code __contains__ check

### DIFF
--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -139,7 +139,7 @@ class BaseWebSocket:
                     "Invalid close frame", WsCloseCode.PROTOCOL_ERROR
                 ) from e
             else:
-                if code < 3000 and (code not in WsCloseCode or code == 1005):
+                if code < 3000 and (code not in WsCloseCode._value2member_map_ or code == 1005):
                     raise WebSocketError(
                         "Invalid close code", WsCloseCode.PROTOCOL_ERROR
                     )


### PR DESCRIPTION
The current code causes an error in Python versions below 3.12 (what were Python developers thinking when they created the enum implementation...)