### PR TITLE
Add support for building curl_cffi wheels on WoA

### DIFF
--- a/libs.json
+++ b/libs.json
@@ -18,13 +18,13 @@
         "so_arch": "i686"
     },
     {
-    "system": "Windows",
-    "machine": "ARM64",
-    "pointer_size": 64,
-    "libdir": "./libarm64",
-    "sysname": "win32",
-    "so_name": "libcurl.dll",
-    "so_arch": "arm64"
+        "system": "Windows",
+        "machine": "ARM64",
+        "pointer_size": 64,
+        "libdir": "./libarm64",
+        "sysname": "win32",
+        "so_name": "libcurl.dll",
+        "so_arch": "arm64"
     },
     {
         "system": "Darwin",

--- a/libs.json
+++ b/libs.json
@@ -18,6 +18,15 @@
         "so_arch": "i686"
     },
     {
+    "system": "Windows",
+    "machine": "ARM64",
+    "pointer_size": 64,
+    "libdir": "./libarm64",
+    "sysname": "win32",
+    "so_name": "libcurl.dll",
+    "so_arch": "arm64"
+    },
+    {
         "system": "Darwin",
         "machine": "x86_64",
         "pointer_size": 64,

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -154,6 +154,7 @@ ffibuilder.set_source(
     include_dirs=[
         str(root_dir / "include"),
         str(root_dir / "ffi"),
+        str(Path(arch["libdir"]) / "include"),
     ],
     sources=[
         str(root_dir / "ffi/shim.c"),


### PR DESCRIPTION
PR Description:

- The minimal patch introduces build support for curl_cffi wheels on Windows on ARM devices
- The changes were related to :
  - adding configs in libs.json to download corresponding libcurl-impersonate Win-ARM64 binaries.
  - Fixed missing includes errors for Win-ARM64 curl headers while building Python wheels.