### PR TITLE
Add support for building Win-ARM64 wheels

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -137,7 +137,3 @@ jobs:
         files: |
           ./dist/*.whl
           ./dist/*.tar.gz
-      with:
-        files: |
-          ./dist/*.whl
-          ./dist/*.tar.gz

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,13 +57,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
+        os: [ubuntu-22.04, macos-13, macos-14, windows-2022, windows-11-arm]
     steps:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v3
@@ -91,13 +91,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     steps:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v3
@@ -133,6 +133,10 @@ jobs:
     - name: Upload release files
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          ./dist/*.whl
+          ./dist/*.tar.gz
       with:
         files: |
           ./dist/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ build = [
     "cp39-macosx_x86_64",
     "cp39-macosx_arm64",
     "cp39-win_amd64",
+    "cp39-win_arm64",
     # "cp39-win32",
     "cp39-manylinux_x86_64",
     "cp39-manylinux_aarch64",
@@ -94,7 +95,7 @@ before-all = "make preprocess"
 test-requires = "pytest"
 test-command = "python -bb -m pytest {project}/tests/unittest"
 test-extras = ["test"]
-test-skip = "cp39-manylinux_i686"  # trustme not available
+test-skip = ["cp39-manylinux_i686", "cp39-win_arm64"]  # trustme not available for manylinux_i686 and cryptography not available for win_arm64
 build-verbosity = 1
 
 


### PR DESCRIPTION
PR Description:

- The PR aims to add support for building curl_cffi python wheel for Windows ARM64
- The following changes are made in order to support Windows ARM64 python wheels:
  - Modified base python version in CI workflow from 3.10 to 3.11, since 3.10 is not available for Windows ARM64
  - Added native windows on arm github runner to support win-arm64 builds
  - Currently, the test cases are skipped for Win-ARM64, since cryptography is not available for Win-ARM64.