### PR TITLE
Respect `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` enviroment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,9 @@ build: .preprocessed
 
 lint:
 	ruff check --exclude issues
-	ruff format --diff
-	mypy --install-types --non-interactive . --exclude 'issues/.*'
 
 format:
-	ruff check --fix
-	ruff format
+	ruff format --exclude issues
 
 test:
 	python -bb -m pytest tests/unittest

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import http.cookies
+import os
 import queue
 import sys
 import threading
@@ -31,7 +32,7 @@ from .exceptions import RequestException, SessionClosed, code2error
 from .headers import Headers, HeaderTypes
 from .impersonate import BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
 from .models import STREAM_END, Response
-from .utils import not_set, set_curl_options, HttpVersionLiteral
+from .utils import HttpVersionLiteral, not_set, set_curl_options
 from .websockets import AsyncWebSocket, WebSocket
 
 with suppress(ImportError):
@@ -236,6 +237,14 @@ class BaseSession(Generic[R]):
             raise ValueError("You need to provide an absolute url for 'base_url'")
 
         self._closed = False
+        # Look for requests environment configuration
+        # and be compatible with cURL.
+        if self.verify is True or self.verify is None:
+            self.verify = (
+                os.environ.get("REQUESTS_CA_BUNDLE")
+                or os.environ.get("CURL_CA_BUNDLE")
+                or self.verify
+            )
 
     def _parse_response(
         self, curl, buffer, header_buffer, default_encoding, discard_cookies

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -536,7 +536,6 @@ def set_curl_options(
         proxies = base_proxies
 
     if proxies:
-
         # Turn on proxy_credential_no_reuse, which has the following benefits:
         # 1. New connection will be made when proxy username changed
         # 2. New TLS session will be created based on proxy address, i.e. when accessing

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -48,6 +48,7 @@ SAFE_CHARS = set("!#$%&'()*+,/:;=?@[]~")
 not_set: Final[Any] = object()
 
 
+# ruff: noqa: SIM116
 def normalize_http_version(
     version: Union[CurlHttpVersion, HttpVersionLiteral],
 ) -> CurlHttpVersion:
@@ -539,7 +540,7 @@ def set_curl_options(
         # Turn on proxy_credential_no_reuse, which has the following benefits:
         # 1. New connection will be made when proxy username changed
         # 2. New TLS session will be created based on proxy address, i.e. when accessing
-        #    the same site with different proxies, the TLS session won't leak previous IP.
+        #    the same site with different proxies, TLS session won't leak previous IP.
         c.setopt(CurlOpt.PROXY_CREDENTIAL_NO_REUSE, 1)
 
         parts = urlparse(url)
@@ -619,7 +620,7 @@ def set_curl_options(
             extra_fp = ExtraFingerprints(**extra_fp)
         if impersonate:
             warnings.warn(
-                "Extra fingerprints was altered after impersonated browser version was set.",
+                "Extra fingerprints was altered after impersonated version was set.",
                 CurlCffiWarning,
                 stacklevel=1,
             )
@@ -629,7 +630,7 @@ def set_curl_options(
     if ja3:
         if impersonate:
             warnings.warn(
-                "JA3 fingerprint was altered after impersonated browser version was set.",
+                "JA3 fingerprint was altered after impersonated version was set.",
                 CurlCffiWarning,
                 stacklevel=1,
             )
@@ -644,7 +645,7 @@ def set_curl_options(
     if akamai:
         if impersonate:
             warnings.warn(
-                "Akamai fingerprint was altered after impersonated browser version was set.",
+                "Akamai fingerprint was altered after impersonated version was set.",
                 CurlCffiWarning,
                 stacklevel=1,
             )

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -527,7 +527,7 @@ class WebSocket(BaseWebSocket):
                         chunks.clear()  # Reset chunks for next message
                     else:
                         full_message = msg
-                    
+
                     if (flags & CurlWsFlag.TEXT) and not self.skip_utf8_validation:
                         try:
                             full_message = full_message.decode()  # type: ignore

--- a/examples/impersonate.py
+++ b/examples/impersonate.py
@@ -52,12 +52,14 @@ print(r.json())
 # Special firefox extension
 
 
+# ruff: noqa: E501
 extra_fp = {
     "tls_delegated_credential": "ecdsa_secp256r1_sha256:ecdsa_secp384r1_sha384:ecdsa_secp521r1_sha512:ecdsa_sha1",
     "tls_record_size_limit": 4001,
 }
 
 # Note that the ja3 string also includes extensiion: 28 and 34
+# ruff: noqa: E501
 ja3 = "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-34-18-51-43-13-45-28-27-65037,4588-29-23-24-25-256-257,0"
 
 r = curl_cffi.get(url, ja3=ja3, extra_fp=extra_fp)


### PR DESCRIPTION
The requests module in `curl_cffi` should respect `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` enviroment variable (just like `requests` does).

This will fix issue ranaroussi/yfinance#2463 where people like me use `yfinance` on a company managed laptop and specified company certificate via `REQUESTS_CA_BUNDLE` enviroment variable.