### PR TITLE
docs: fix impersonation docs link in README to working URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ If you don't want to look up the headers etc, by yourself, consider buying comme
 we have comprehensive browser fingerprints database for almost all the browser versions on various platforms.
 
 If you are trying to impersonate a target other than a browser, use `ja3=...` and `akamai=...`
-to specify your own customized fingerprints. See the [docs on impersonation](https://curl-cffi.readthedocs.io/en/latest/impersonate.html) for details.
+to specify your own customized fingerprints. See the [docs on impersonation](https://curl-cffi.readthedocs.io/en/latest/impersonate/_index.html) for details.
 
 |Browser|Open Source| Pro version|
 |---|---|---|


### PR DESCRIPTION
Updated the impersonation documentation link in the **README** to point to the correct working URL:
- Changed from `https://curl-cffi.readthedocs.io/en/latest/impersonate.html`
- To `https://curl-cffi.readthedocs.io/en/latest/impersonate/_index.html`
