### PR TITLE
refactor: enhance Curl class cleanup methods

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -374,8 +374,8 @@ class Curl:
     def clean_handles_and_buffers(
         self, clear_headers: bool = True, clear_resolve: bool = True
     ) -> None:
-        """Clean up handles and buffers after ``perform``, called at the end of
-        ``perform``."""
+        """Clean up handles and buffers after ``perform`` and ``close``, called at the end of
+        ``perform`` and ``close``."""
         self._write_handle = None
         self._header_handle = None
         self._debug_handle = None

--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -346,11 +346,12 @@ class Curl:
             ret = self.setopt(CurlOpt.PROXY_CAINFO, self._cacert)
             self._check_error(ret, "set proxy cacert")
 
-    def perform(self, clear_headers: bool = True) -> None:
+    def perform(self, clear_headers: bool = True, clear_resolve: bool = True) -> None:
         """Wrapper for ``curl_easy_perform``, performs a curl request.
 
         Parameters:
             clear_headers: clear header slist used in this perform
+            clear_resolve: clear resolve slist used in this perform
 
         Raises:
             CurlError: if the perform was not successful.
@@ -365,18 +366,26 @@ class Curl:
             self._check_error(ret, "perform")
         finally:
             # cleaning
-            self.clean_after_perform(clear_headers)
+            self.clean_handles_and_buffers(clear_headers, clear_resolve)
 
     def upkeep(self) -> int:
         return lib.curl_easy_upkeep(self._curl)
 
-    def clean_after_perform(self, clear_headers: bool = True) -> None:
+    def clean_handles_and_buffers(
+        self, clear_headers: bool = True, clear_resolve: bool = True
+    ) -> None:
         """Clean up handles and buffers after ``perform``, called at the end of
         ``perform``."""
         self._write_handle = None
         self._header_handle = None
         self._debug_handle = None
         self._body_handle = None
+
+        if clear_resolve:
+            if self._resolve != ffi.NULL:
+                lib.curl_slist_free_all(self._resolve)
+            self._resolve = ffi.NULL
+
         if clear_headers:
             if self._headers != ffi.NULL:
                 lib.curl_slist_free_all(self._headers)
@@ -450,11 +459,12 @@ class Curl:
 
     def close(self) -> None:
         """Close and cleanup curl handle, wrapper for ``curl_easy_cleanup``."""
+        self.clean_handles_and_buffers()
+
         if self._curl:
             lib.curl_easy_cleanup(self._curl)
             self._curl = None
         ffi.release(self._error_buffer)
-        self._resolve = ffi.NULL
 
     def ws_recv(self, n: int = 1024) -> tuple[bytes, CurlWsFrame]:
         """Receive a frame from a websocket connection.

--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -374,8 +374,8 @@ class Curl:
     def clean_handles_and_buffers(
         self, clear_headers: bool = True, clear_resolve: bool = True
     ) -> None:
-        """Clean up handles and buffers after ``perform`` and ``close``, called at the end of
-        ``perform`` and ``close``."""
+        """Clean up handles and buffers after ``perform`` and ``close``, 
+        called at the end of ``perform`` and ``close``."""
         self._write_handle = None
         self._header_handle = None
         self._debug_handle = None

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -553,12 +553,12 @@ class Session(BaseSession[R]):
             files=files,
             auth=auth or self.auth,
             timeout=self.timeout if timeout is not_set else timeout,
-            allow_redirects=self.allow_redirects
-            if allow_redirects is None
-            else allow_redirects,
-            max_redirects=self.max_redirects
-            if max_redirects is None
-            else max_redirects,
+            allow_redirects=(
+                self.allow_redirects if allow_redirects is None else allow_redirects
+            ),
+            max_redirects=(
+                self.max_redirects if max_redirects is None else max_redirects
+            ),
             proxies_list=[self.proxies, proxies],
             proxy=proxy,
             proxy_auth=proxy_auth or self.proxy_auth,
@@ -570,9 +570,9 @@ class Session(BaseSession[R]):
             ja3=ja3 or self.ja3,
             akamai=akamai or self.akamai,
             extra_fp=extra_fp or self.extra_fp,
-            default_headers=self.default_headers
-            if default_headers is None
-            else default_headers,
+            default_headers=(
+                self.default_headers if default_headers is None else default_headers
+            ),
             quote=quote,
             http_version=http_version or self.http_version,
             interface=interface or self.interface,
@@ -799,7 +799,7 @@ class AsyncSession(BaseSession[R]):
                 break
 
     def release_curl(self, curl):
-        curl.clean_after_perform()
+        curl.clean_handles_and_buffers()
         if not self._closed:
             self.acurl.remove_handle(curl)
             curl.reset()
@@ -900,12 +900,12 @@ class AsyncSession(BaseSession[R]):
             cookies_list=[self.cookies, cookies],
             auth=auth or self.auth,
             timeout=self.timeout if timeout is not_set else timeout,
-            allow_redirects=self.allow_redirects
-            if allow_redirects is None
-            else allow_redirects,
-            max_redirects=self.max_redirects
-            if max_redirects is None
-            else max_redirects,
+            allow_redirects=(
+                self.allow_redirects if allow_redirects is None else allow_redirects
+            ),
+            max_redirects=(
+                self.max_redirects if max_redirects is None else max_redirects
+            ),
             proxies_list=[self.proxies, proxies],
             proxy=proxy,
             proxy_auth=proxy_auth or self.proxy_auth,
@@ -916,9 +916,9 @@ class AsyncSession(BaseSession[R]):
             ja3=ja3 or self.ja3,
             akamai=akamai or self.akamai,
             extra_fp=extra_fp or self.extra_fp,
-            default_headers=self.default_headers
-            if default_headers is None
-            else default_headers,
+            default_headers=(
+                self.default_headers if default_headers is None else default_headers
+            ),
             quote=quote,
             http_version=http_version or self.http_version,
             interface=interface or self.interface,
@@ -990,12 +990,12 @@ class AsyncSession(BaseSession[R]):
             files=files,
             auth=auth or self.auth,
             timeout=self.timeout if timeout is not_set else timeout,
-            allow_redirects=self.allow_redirects
-            if allow_redirects is None
-            else allow_redirects,
-            max_redirects=self.max_redirects
-            if max_redirects is None
-            else max_redirects,
+            allow_redirects=(
+                self.allow_redirects if allow_redirects is None else allow_redirects
+            ),
+            max_redirects=(
+                self.max_redirects if max_redirects is None else max_redirects
+            ),
             proxies_list=[self.proxies, proxies],
             proxy=proxy,
             proxy_auth=proxy_auth or self.proxy_auth,
@@ -1007,9 +1007,9 @@ class AsyncSession(BaseSession[R]):
             ja3=ja3 or self.ja3,
             akamai=akamai or self.akamai,
             extra_fp=extra_fp or self.extra_fp,
-            default_headers=self.default_headers
-            if default_headers is None
-            else default_headers,
+            default_headers=(
+                self.default_headers if default_headers is None else default_headers
+            ),
             quote=quote,
             http_version=http_version or self.http_version,
             interface=interface or self.interface,


### PR DESCRIPTION
It probably fixes #613 

- Added `clear_resolve` parameter to `perform` method for better resource management.
- Renamed `clean_after_perform` to `clean_handles_and_buffers` for clarity and updated its logic to handle resolve list cleanup.
- Added a call to `clean_handles_and_buffers` on `close` method.
- Updated calls to the cleanup method across the codebase to reflect the new method name and parameters.