### PR TITLE
CLI script `curl-cffi`

### DIFF
--- a/curl_cffi/cli.py
+++ b/curl_cffi/cli.py
@@ -1,0 +1,32 @@
+import argparse
+import sys
+import curl_cffi
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="curl-cffi",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="A curl-like tool using curl-cffi with browser impersonation",
+    )
+    parser.add_argument(
+        "-i",
+        "--impersonate",
+        default="chrome",
+        help="Browser to impersonate",
+    )
+    parser.add_argument("urls", nargs="+", help="URLs to fetch")
+
+    args = parser.parse_args()
+
+    for url in args.urls:
+        try:
+            response = curl_cffi.requests.get(url, impersonate=args.impersonate)
+            print(response.text)
+        except Exception as e:
+            print(f"Error fetching {url}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ test = [
     "typing_extensions",
 ]
 
+[project.scripts]
+curl-cffi = "curl_cffi.cli:main"
 
 [build-system]
 requires = ["wheel", "setuptools", "cffi>=1.12.0"]

--- a/tests/unittest/test_cli.py
+++ b/tests/unittest/test_cli.py
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def test_cli(server):
+    """Test that the curl-cffi CLI can perform basic GET requests."""
+    result = subprocess.check_output(
+        f"curl-cffi {server.url}",
+        shell=True,
+        text=True,
+        timeout=30,
+    )
+    # Should look like HTTP response:
+    assert "Hello, world!" in result


### PR DESCRIPTION
A handy shortcut to use in command line without installing a package: `uvx curl-cffi https://url1 https://url2 ...`.