### PR TITLE
Add raise_for_status parameter to Session and AsyncSession

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -386,7 +386,8 @@ class Session(BaseSession[R]):
                 automatic detection.
             cert: a tuple of (cert, key) filenames for client cert.
             response_class: A customized subtype of ``Response`` to use.
-            raise_for_status: automatically raise an HTTPError for 4xx and 5xx status codes.
+            raise_for_status: automatically raise an HTTPError for 4xx and 5xx
+                status codes.
 
         Notes:
             This class can be used as a context manager.
@@ -738,7 +739,8 @@ class AsyncSession(BaseSession[R]):
                 automatic detection.
             cert: a tuple of (cert, key) filenames for client cert.
             response_class: A customized subtype of ``Response`` to use.
-            raise_for_status: automatically raise an HTTPError for 4xx and 5xx status codes.
+            raise_for_status: automatically raise an HTTPError for 4xx and 5xx
+                status codes.
 
         Notes:
             This class can be used as a context manager, and it's recommended to use via

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -467,13 +467,14 @@ async def test_async_session_auto_raise_for_status_enabled(server):
     async with AsyncSession(raise_for_status=True) as s:
         try:
             await s.get(str(server.url.copy_with(path="/status/404")))
-            assert False, "Should have raised HTTPError for 404"
+            raise AssertionError("Should have raised HTTPError for 404")
         except HTTPError as e:
             assert e.response.status_code == 404  # type: ignore
 
 
 async def test_async_session_auto_raise_for_status_disabled(server):
-    """Test that AsyncSession does NOT raise HTTPError when raise_for_status=False (default)"""
+    """Test that AsyncSession does NOT raise HTTPError when raise_for_status=False
+    (default)"""
     async with AsyncSession(raise_for_status=False) as s:
         r = await s.get(str(server.url.copy_with(path="/status/404")))
         assert r.status_code == 404

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -990,13 +990,14 @@ def test_session_auto_raise_for_status_enabled(server):
     s = requests.Session(raise_for_status=True)
     try:
         s.get(str(server.url.copy_with(path="/status/404")))
-        assert False, "Should have raised HTTPError for 404"
+        raise AssertionError("Should have raised HTTPError for 404")
     except HTTPError as e:
         assert e.response.status_code == 404  # type: ignore
 
 
 def test_session_auto_raise_for_status_disabled(server):
-    """Test that Session does NOT raise HTTPError when raise_for_status=False (default)"""
+    """Test that Session does NOT raise HTTPError when raise_for_status=False
+    (default)"""
     s = requests.Session(raise_for_status=False)
     r = s.get(str(server.url.copy_with(path="/status/404")))
     assert r.status_code == 404


### PR DESCRIPTION
- Add raise_for_status parameter (default: False) to both Session and AsyncSession
- Automatically raises HTTPError for 4xx/5xx status codes when enabled
- Similar to aiohttp's raise_for_status parameter
- Add 4 unit tests (2 sync, 2 async) to verify functionality
- Maintains 100% backward compatibility with default False value

Close #646 