### PR TITLE
pytest crashes intermittently after completion with websockets.exceptions.ConnectionClosedError

### DIFF
--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -624,7 +624,6 @@ async def echo(websocket):
             # Client sent us a close frame: echo it back exactly
             await websocket.close(code=e.code, reason=e.reason)
 
-
 class TestWebsocketServer:
     def __init__(self, port):
         self.url = f"ws://127.0.0.1:{port}"
@@ -633,8 +632,11 @@ class TestWebsocketServer:
     def run(self):
         async def serve(port):
             # GitHub actions only likes 127, not localhost, wtf...
-            async with websockets.serve(echo, "127.0.0.1", port):  # pyright: ignore
-                await asyncio.Future()  # run forever
+            try:
+                async with websockets.serve(echo, "127.0.0.1", port):  # pyright: ignore
+                    await asyncio.Future()  # run forever
+            except websockets.exceptions.ConnectionClosedError:
+                return
 
         asyncio.run(serve(self.port))
 


### PR DESCRIPTION
While building in the [NixOS/nixpkgs]() [CI](https://hydra.nixos.org/build/311365966/nixlog/1/tail) ("Hydra"):

```sh
========== 175 passed, 17 skipped, 8 deselected, 82 warnings in 6.83s ==========
connection handler failed
Traceback (most recent call last):
  File "/nix/store/xigjdkrvnqj74amncql98f1bzs4r1g6v-python3.13-websockets-15.0.1/lib/python3.13/site-packages/websockets/asyncio/server.py", line 376, in conn_handler
    await self.handler(connection)
  File "/build/source/tests/unittest/conftest.py", line 618, in echo
    name = await websocket.recv()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/xigjdkrvnqj74amncql98f1bzs4r1g6v-python3.13-websockets-15.0.1/lib/python3.13/site-packages/websockets/asyncio/connection.py", line 322, in recv
    raise self.protocol.close_exc from self.recv_exc
websockets.exceptions.ConnectionClosedError: no close frame received or sent
Hello, world!Hello, world!Hello, world!Hello, world!Redirecting...Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!Hello, world!Fatal Python error: _enter_buffered_busy: could not acquire lock for <_io.BufferedWriter name='<stderr>'> at interpreter shutdown, possibly due to daemon threads
Python runtime state: finalizing (tstate=0x0000fffff7f3e2b0)

Current thread 0x0000fffff7ff4ec0 (most recent call first):
  <no Python frame>

Extension modules: _cffi_backend, charset_normalizer.md, websockets.speedups (total: 3)
/nix/store/ypaywzh12y8x2w4v1vsqd3w13vfz260q-pytest-check-hook/nix-support/setup-hook: line 23:   250 Aborted                    (core dumped) /nix/store/m0b67b3lmjcxa8aplpl75qpb26gr5vsf-python3-3.13.8/bin/python3.13 "${flagsArray[@]}"
```

This is breaking in the `echo` method. Websocket connections can close unexpectedly, such as when either side goes offline, and should throw an error (`websockets.exceptions.ConnectionClosedError` in this case). See https://datatracker.ietf.org/doc/html/rfc6455#section-7.2

In this case, we've torn down the test environment and the server happened to be closed first. It's a classic client-server race condition. This causes the test to fail intermittently.

Since nixpkgs rebuilds a package whenever its dependencies update, a rare failure can cause that build to break; it remains broken until someone files a PR to fix the breakage).

This patch catches the `ConnectionClosedError` and turns it into a `pass`. A warning might be more suitable, though if the test environment is being torn down this could cause its own problems.