### PR TITLE
Fix Content-Type header update for non-empty data in set_curl_options

### DIFF
--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -455,7 +455,7 @@ def set_curl_options(
         update_header_line(
             header_lines, "Content-Type", "application/x-www-form-urlencoded"
         )
-    if isinstance(data, (str, bytes)):
+    if isinstance(data, (str, bytes)) and data:
         update_header_line(header_lines, "Content-Type", "application/octet-stream")
 
     # Never send `Expect` header.


### PR DESCRIPTION
Previously, `data=""` or `data=b""` was treated as a real request body, causing `Content-Type: application/octet-stream` to be added. This was inconsistent with `data=None`, and it led to overwriting valid user-provided headers.

#### Issue Example

In parameterized request flows:

```python
http_session = AsyncSession(...)
response = await http_session.request(
    method=METHOD,
    url=URL,
    data=POST_DATA,    # may be "" when no body is intended
    headers=HEADERS,
    verify=False,
    impersonate=impersonate,
    timeout=_timeout,
    default_headers=False,
)
```

If `POST_DATA=""`, the old behavior forced:

```
Content-Type: application/octet-stream
```

which **overrode** user intent and broke GET requests where an empty body is not actually a payload.

#### Fix

Only apply the default content-type if the string/bytes payload is **non-empty**:

```diff
- if isinstance(data, (str, bytes)):
+ if isinstance(data, (str, bytes)) and data:
```

This restores expected behavior:

* `data=None` → no content-type added
* `data=""` → no content-type added
* `data="foobar"` → defaults to `application/octet-stream` (unchanged)

