### PR TITLE
Typehint session return values and internal functions

### DIFF
--- a/curl_cffi/requests/headers.py
+++ b/curl_cffi/requests/headers.py
@@ -102,7 +102,7 @@ class Headers(MutableMapping[str, Optional[str]]):
             ]
         elif isinstance(headers, list):
             # list of "Name: Value" pairs
-            if isinstance(headers[0], (str, bytes)):
+            if isinstance(headers[0], str | bytes):
                 sep = ":" if isinstance(headers[0], str) else b":"
                 h = []
                 for line in headers:

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -13,8 +13,6 @@ from collections.abc import Callable
 from io import BytesIO
 from typing import (
     TYPE_CHECKING,
-    AsyncGenerator,
-    Generator,
     Generic,
     Literal,
     Optional,
@@ -23,6 +21,7 @@ from typing import (
     Union,
     cast,
 )
+from collections.abc import AsyncGenerator, Generator
 from urllib.parse import urlparse
 from datetime import timedelta
 
@@ -247,12 +246,12 @@ class BaseSession(Generic[R]):
             )
 
     def _parse_response(
-        self, 
-        curl: Curl, 
-        buffer: BytesIO, 
-        header_buffer: BytesIO, 
-        default_encoding: Union[str, Callable[[bytes], str]], 
-        discard_cookies:bool
+        self,
+        curl: Curl,
+        buffer: BytesIO,
+        header_buffer: BytesIO,
+        default_encoding: Union[str, Callable[[bytes], str]],
+        discard_cookies: bool,
     ) -> R:
         c = curl
         rsp = cast(R, self.response_class(c))
@@ -469,7 +468,13 @@ class Session(BaseSession[R]):
             rsp.close()
 
     def ws_connect(
-        self, url: str, on_message=None, on_error=None, on_open=None, on_close=None, **kwargs
+        self,
+        url: str,
+        on_message=None,
+        on_error=None,
+        on_open=None,
+        on_close=None,
+        **kwargs,
     ) -> WebSocket:
         """Connects to a websocket url.
 
@@ -798,11 +803,11 @@ class AsyncSession(BaseSession[R]):
             curl = Curl(debug=self.debug)
         return curl
 
-    def push_curl(self, curl: Curl | None) -> None: 
+    def push_curl(self, curl: Curl | None) -> None:
         with suppress(asyncio.QueueFull):
             self.pool.put_nowait(curl)
 
-    async def __aenter__(self): # TODO: -> Self
+    async def __aenter__(self):  # TODO: -> Self
         return self
 
     async def __aexit__(self, *args) -> None:

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -118,7 +118,7 @@ def update_url_params(url: str, params: Union[dict, list, tuple]) -> str:
     new_args_counter = Counter(x[0] for x in params)
     for key, value in params:
         # Bool and Dict values should be converted to json-friendly values
-        if isinstance(value, (bool, dict)):
+        if isinstance(value, bool | dict):
             value = dumps(value)
         # 1 to 1 mapping, we have to search and update it.
         if old_args_counter.get(key) == 1 and new_args_counter.get(key) == 1:
@@ -395,7 +395,7 @@ def set_curl_options(
     c.setopt(CurlOpt.URL, url.encode())
 
     # data/body/json
-    if isinstance(data, (dict, list, tuple)):
+    if isinstance(data, dict | list | tuple):
         body = urlencode(data).encode()
     elif isinstance(data, str):
         body = data.encode()
@@ -455,7 +455,7 @@ def set_curl_options(
         update_header_line(
             header_lines, "Content-Type", "application/x-www-form-urlencoded"
         )
-    if isinstance(data, (str, bytes)) and data:
+    if isinstance(data, str | bytes) and data:
         update_header_line(header_lines, "Content-Type", "application/octet-stream")
 
     # Never send `Expect` header.
@@ -514,7 +514,7 @@ def set_curl_options(
             c.setopt(CurlOpt.LOW_SPEED_LIMIT, 1)
             c.setopt(CurlOpt.LOW_SPEED_TIME, math.ceil(all_timeout))
 
-    elif isinstance(timeout, (int, float)):
+    elif isinstance(timeout, int | float):
         if not stream:
             c.setopt(CurlOpt.TIMEOUT_MS, int(timeout * 1000))
         else:

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -906,7 +906,7 @@ class AsyncWebSocket(BaseWebSocket):
         # cURL expects bytes
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
-        elif isinstance(payload, (bytearray, memoryview)):
+        elif isinstance(payload, bytearray | memoryview):
             payload = bytes(payload)
 
         try:


### PR DESCRIPTION
Found this library to be rather useful for newer protocols and I wanted to lend a hand while I wait for things to be done with aiohttp (since I'm a contributor over there). One of which being type hints since type hinting code lowers the chance of the developer screwing up and helps keep things up to date. I would've ran ruff or mypy but I wanted to get permission first before I attempt to do something like that so for now I'll just type hint what I thought was missing from this project.

I also used Pipes instead of Union or Optional since 3.9 has been dropped from this project and it would be a good idea to migrate to this new annotation style in the future.

I marked -> Self as a TODO since I don't know how the maintainers wanted to go about adding that in Otherwise I would suggest wrapping `AsyncSession` and `Session` around a `@final` wrapper similar to what is in aiohttp.
