### PR TITLE
Add support for CURLOPT_CONNECT_TO

### DIFF
--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 import pytest
 
 from curl_cffi import Headers
+from curl_cffi.const import CurlOpt
 from curl_cffi.requests import AsyncSession, RequestsError
 from curl_cffi.requests.errors import SessionClosed
 
@@ -206,6 +207,22 @@ async def test_referer(server):
         r = await s.get(
             str(server.url.copy_with(path="/echo_headers")),
             referer="http://example.com",
+        )
+        headers = r.json()
+        assert headers["Referer"][0] == "http://example.com"
+
+
+async def test_curl_options(server):
+    async with AsyncSession(
+        curl_options={CurlOpt.HTTPHEADER: [b"Referer: http://example.com"]}
+    ) as s:
+        r = await s.get(
+            "http://example.com/echo_headers",
+            curl_options={
+                CurlOpt.CONNECT_TO: [
+                    f"example.com::{server.config.host}:{server.config.port}"
+                ]
+            },
         )
         headers = r.json()
         assert headers["Referer"][0] == "http://example.com"

--- a/tests/unittest/test_curl.py
+++ b/tests/unittest/test_curl.py
@@ -336,6 +336,17 @@ def test_resolve(server):
     c.perform()
 
 
+def test_connect_to(server):
+    c = Curl()
+    url = "http://example.com:8000"
+    c.setopt(
+        CurlOpt.CONNECT_TO,
+        [f"example.com:8000:{server.config.host}:{server.config.port}"],
+    )
+    c.setopt(CurlOpt.URL, url)
+    c.perform()
+
+
 def test_duphandle(server):
     c = Curl()
     c.setopt(CurlOpt.URL, str(server.url.copy_with(path="/redirect_loop")).encode())


### PR DESCRIPTION
I have added support for setting the CONNECT_TO option value.

Additionally for my use case I wanted to set it on a per request basis in an async session, so I have added support for passing curl_options directly in the session request method and merge it with the instance curl_options.