### PR TITLE
Add support for loongarch64

### DIFF
--- a/libs.json
+++ b/libs.json
@@ -136,5 +136,15 @@
         "libc": "gnueabihf",
         "obj_name": "libcurl-impersonate.a",
         "arch": "arm"
+    },
+    {
+        "system": "Linux",
+        "machine": "loongarch64",
+        "pointer_size": 64,
+        "sysname": "linux",
+        "link_type": "static",
+        "libc": "gnu",
+        "obj_name": "libcurl-impersonate.a",
+        "arch": "loongarch64"
     }
 ]


### PR DESCRIPTION
Hello,

I have added the loongarch64 configuration entry to libs.json, since curl-impersonate already provides a loongarch64 release.
https://github.com/lexiforest/curl-impersonate/pull/210#issuecomment-3844930667

At the moment, I have not included any CI-related code changes, because loongarch64 has not yet been officially accepted by PyPA.