### PR TITLE
Fixes for heap corruption due to thread safety issue

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -404,12 +404,20 @@ class Curl:
             ret = self.setopt(CurlOpt.PROXY_CAINFO, self._cacert)
             self._check_error(ret, "set proxy cacert")
 
-    def perform(self, clear_headers: bool = True, clear_resolve: bool = True) -> None:
+    def perform(
+        self,
+        clear_headers: bool = True,
+        clear_resolve: bool = True,
+        auto_cleanup: bool = True,
+    ) -> None:
         """Wrapper for ``curl_easy_perform``, performs a curl request.
 
         Parameters:
             clear_headers: clear header slist used in this perform
             clear_resolve: clear resolve slist used in this perform
+            auto_cleanup: if True, automatically clean handles and buffers after
+                perform. Set to False when the caller needs to read response info
+                (e.g. via getinfo) before cleanup.
 
         Raises:
             CurlError: if the perform was not successful.
@@ -426,8 +434,8 @@ class Curl:
         try:
             self._check_error(ret, "perform")
         finally:
-            # cleaning
-            self.clean_handles_and_buffers(clear_headers, clear_resolve)
+            if auto_cleanup:
+                self.clean_handles_and_buffers(clear_headers, clear_resolve)
 
     def upkeep(self) -> int:
         if self._curl is None:

--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -249,7 +249,9 @@ class Response:
         with self._stream_close_lock:
             if self._stream_closed:
                 return
-            if self.queue is None and self.stream_task is None and self.quit_now is None:
+            if self.queue is None and \
+                self.stream_task is None and \
+                self.quit_now is None:
                 return
             self._stream_closed = True
         if self.quit_now:

--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -1,6 +1,7 @@
 from contextlib import suppress
 import queue
 import re
+import threading
 import warnings
 from concurrent.futures import Future
 from typing import Any, Optional, Union
@@ -103,6 +104,8 @@ class Response:
         self.astream_task: Optional[Awaitable] = None
         self.quit_now = None
         self._stream_closed = False
+        self._stream_close_lock = threading.Lock()
+        self._release_curl: Optional[Callable] = None
         self.download_size: int = 0
         self.upload_size: int = 0
         self.header_size: int = 0
@@ -243,16 +246,21 @@ class Response:
         self._finalize_stream()
 
     def _finalize_stream(self) -> None:
-        if self._stream_closed:
-            return
-        if self.queue is None and self.stream_task is None and self.quit_now is None:
-            return
-        self._stream_closed = True
+        with self._stream_close_lock:
+            if self._stream_closed:
+                return
+            if self.queue is None and self.stream_task is None and self.quit_now is None:
+                return
+            self._stream_closed = True
         if self.quit_now:
             self.quit_now.set()
         if self.stream_task:
             self.stream_task.result()
-        if self.curl:
+        # Return handle to pool if a release callback is set, otherwise close it
+        if self._release_curl and self.curl:
+            self._release_curl(self.curl)
+            self._release_curl = None
+        elif self.curl:
             self.curl.close()
 
     async def aiter_lines(self, chunk_size=None, decode_unicode=False, delimiter=None):

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -434,7 +434,8 @@ class Session(BaseSession[R]):
             max_pool_size: when set to a positive integer, use a pool of curl handles
                 instead of a single thread-local handle. This enables safe concurrent
                 requests across threads. Each request pops a handle from the pool and
-                returns it when done. Streaming responses hold their handle until closed.
+                returns it when done. 
+                Streaming responses hold their handle until closed.
             headers: headers to use in the session.
             cookies: cookies to add in the session.
             auth: HTTP basic auth, a tuple of (username, password), only basic auth is

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -398,14 +398,27 @@ class BaseSession(Generic[R]):
 
 
 class Session(BaseSession[R]):
-    """A request session, cookies and connections will be reused. This object is
-    thread-safe, but it's recommended to use a separate session for each thread."""
+    """A request session, cookies and connections will be reused.
+
+    Each thread that uses this session gets its own curl handle via
+    thread-local storage, so concurrent requests from different threads
+    are safe. However, within a single thread, only one request may be
+    in-flight at a time unless ``max_pool_size`` is set.
+
+    When ``max_pool_size`` is set to a positive integer, the session uses
+    a pool of curl handles instead of thread-local storage, enabling
+    concurrent requests across threads. Note that pool mode does not
+    support direct ``session.curl`` customization via ``setopt()``.
+
+    For full async concurrency, use ``AsyncSession`` which maintains a handle pool.
+    """
 
     def __init__(
         self,
         curl: Optional[Curl] = None,
         thread: Optional[ThreadType] = None,
         use_thread_local_curl: bool = True,
+        max_pool_size: int = 0,
         **kwargs: Unpack[BaseSessionParams[R]],
     ) -> None:
         """
@@ -418,6 +431,10 @@ class Session(BaseSession[R]):
                 from another thread.
             thread: thread engine to use for working with other thread implementations.
                 choices: eventlet, gevent.
+            max_pool_size: when set to a positive integer, use a pool of curl handles
+                instead of a single thread-local handle. This enables safe concurrent
+                requests across threads. Each request pops a handle from the pool and
+                returns it when done. Streaming responses hold their handle until closed.
             headers: headers to use in the session.
             cookies: cookies to add in the session.
             auth: HTTP basic auth, a tuple of (username, password), only basic auth is
@@ -461,18 +478,32 @@ class Session(BaseSession[R]):
         super().__init__(**kwargs)
         self._thread = thread
         self._use_thread_local_curl = use_thread_local_curl
+        self._max_pool_size = max_pool_size
         self._queue = None
         self._executor = None
-        if use_thread_local_curl:
-            self._local = threading.local()
-            if curl:
-                self._is_customized_curl = True
-                self._local.curl = curl
-            else:
-                self._is_customized_curl = False
-                self._local.curl = Curl(debug=self.debug)
-        else:
+
+        if max_pool_size > 0:
+            # Pool mode: use a LifoQueue of curl handles for concurrent access
+            self._pool: Optional[queue.LifoQueue[Optional[Curl]]] = queue.LifoQueue(
+                maxsize=max_pool_size
+            )
+            for _ in range(max_pool_size):
+                self._pool.put_nowait(None)  # lazy placeholders
+            # Keep a primary handle for backward compat (upkeep, ws_connect, etc.)
+            self._use_thread_local_curl = False
             self._curl = curl if curl else Curl(debug=self.debug)
+        else:
+            self._pool = None
+            if use_thread_local_curl:
+                self._local = threading.local()
+                if curl:
+                    self._is_customized_curl = True
+                    self._local.curl = curl
+                else:
+                    self._is_customized_curl = False
+                    self._local.curl = Curl(debug=self.debug)
+            else:
+                self._curl = curl if curl else Curl(debug=self.debug)
 
     @property
     def curl(self):
@@ -495,6 +526,26 @@ class Session(BaseSession[R]):
             self._executor = ThreadPoolExecutor()
         return self._executor
 
+    def _pop_curl(self) -> Curl:
+        """Get a curl handle from the pool. Blocks if pool is exhausted."""
+        assert self._pool is not None
+        curl = self._pool.get()
+        if curl is None:
+            curl = Curl(debug=self.debug)
+        return curl
+
+    def _push_curl(self, curl: Curl) -> None:
+        """Return a curl handle to the pool."""
+        if self._pool is not None and not self._closed:
+            curl.clean_handles_and_buffers()
+            curl.reset()
+            try:
+                self._pool.put_nowait(curl)
+            except queue.Full:
+                curl.close()
+        else:
+            curl.close()
+
     def __enter__(self):
         return self
 
@@ -504,6 +555,14 @@ class Session(BaseSession[R]):
     def close(self) -> None:
         """Close the session."""
         self._closed = True
+        if self._pool is not None:
+            while True:
+                try:
+                    curl = self._pool.get_nowait()
+                    if curl is not None:
+                        curl.close()
+                except queue.Empty:
+                    break
         self.curl.close()
 
     @contextmanager
@@ -614,8 +673,12 @@ class Session(BaseSession[R]):
         multipart: Optional[CurlMime] = None,
         discard_cookies: bool = False,
     ) -> R:
-        # clone a new curl instance for streaming response
-        if stream:
+        # Determine which curl handle to use
+        if self._pool is not None:
+            # Pool mode: each request gets its own handle from the pool
+            c = self._pop_curl()
+        elif stream:
+            # Thread-local mode: clone a new curl instance for streaming response
             c = self.curl.duphandle()
             _ = self.curl.reset()
         else:
@@ -670,7 +733,7 @@ class Session(BaseSession[R]):
 
             def perform():
                 try:
-                    c.perform()
+                    c.perform(auto_cleanup=False)
                 except CurlError as e:
                     rsp = self._parse_response(
                         c, buffer, header_buffer, default_encoding, discard_cookies
@@ -678,6 +741,7 @@ class Session(BaseSession[R]):
                     rsp.request = req
                     q.put_nowait(RequestException(str(e), e.code, rsp))  # type: ignore
                 finally:
+                    c.clean_handles_and_buffers()
                     if not cast(threading.Event, header_recved).is_set():
                         cast(threading.Event, header_recved).set()
                     q.put(STREAM_END)  # type: ignore
@@ -696,13 +760,18 @@ class Session(BaseSession[R]):
                 if quit_now:
                     quit_now.set()
                 stream_task.result()
-                c.close()
+                if self._pool is not None:
+                    self._push_curl(c)
+                else:
+                    c.close()
                 raise first_element
 
             rsp.request = req
             rsp.stream_task = stream_task
             rsp.quit_now = quit_now
             rsp.queue = q
+            if self._pool is not None:
+                rsp._release_curl = self._push_curl
             if self.raise_for_status:
                 rsp.raise_for_status()
             return rsp
@@ -712,14 +781,18 @@ class Session(BaseSession[R]):
                     # see: https://eventlet.net/doc/threading.html
                     import eventlet.tpool
 
-                    eventlet.tpool.execute(c.perform)  # type: ignore
+                    eventlet.tpool.execute(
+                        lambda: c.perform(auto_cleanup=False)
+                    )  # type: ignore
                 elif self._thread == "gevent":
                     # see: https://www.gevent.org/api/gevent.threadpool.html
                     import gevent
 
-                    gevent.get_hub().threadpool.spawn(c.perform).get()  # type: ignore
+                    gevent.get_hub().threadpool.spawn(
+                        lambda: c.perform(auto_cleanup=False)
+                    ).get()  # type: ignore
                 else:
-                    c.perform()
+                    c.perform(auto_cleanup=False)
             except CurlError as e:
                 rsp = self._parse_response(
                     c, buffer, header_buffer, default_encoding, discard_cookies
@@ -736,7 +809,11 @@ class Session(BaseSession[R]):
                     rsp.raise_for_status()
                 return rsp
             finally:
-                c.reset()
+                if self._pool is not None:
+                    self._push_curl(c)
+                else:
+                    c.clean_handles_and_buffers()
+                    c.reset()
 
     def request(
         self,


### PR DESCRIPTION
# Problem 

When `curl_easy_perform` fails, the handles get deallocated, but the caller of the method then tries to get the cookies from that same memory space, which is a use-after-free issue. This can cause heap corruption errors on Windows (and generally memory errors on any system). There is also a double-free issue with `Response._finalize_stream()` that can cause concurrent deletes to be possible. 

# Fix

Added an optional param `auto_cleanup` that lets the caller avoid cleanup if they intend to use the class after an error

Added general thread safety around curl methods as they are specifically not promised to be thread safe.