### PR TITLE
fix: multipart filename not overriding local path base name

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -733,12 +733,6 @@ class CurlMime:
             if ret != 0:
                 raise CurlError("Add field failed.")
 
-        # remote file name
-        if filename is not None:
-            ret = lib.curl_mime_filename(part, filename.encode())
-            if ret != 0:
-                raise CurlError("Add field failed.")
-
         if local_path and data:
             raise CurlError("Can not use local_path and data at the same time.")
 
@@ -754,6 +748,12 @@ class CurlMime:
             if not Path(local_path_str).exists():
                 raise FileNotFoundError(f"File not found at {local_path_str}")
             ret = lib.curl_mime_filedata(part, local_path_str.encode())
+            if ret != 0:
+                raise CurlError("Add field failed.")
+
+        # remote file name
+        if filename is not None:
+            ret = lib.curl_mime_filename(part, filename.encode())
             if ret != 0:
                 raise CurlError("Add field failed.")
 


### PR DESCRIPTION
https://curl.se/libcurl/c/curl_mime_filedata.html

> _filename_ points to the null-terminated file's path name. The pointer can be NULL to detach the previous part contents settings. Filename storage can be safely be reused after this call.

> As a side effect, the part's remote filename is set to the base name of the given filename if it is a valid named file. This can be undone or overridden by a subsequent call to [curl_mime_filename](https://curl.se/libcurl/c/curl_mime_filename.html). 

moving `curl_mime_filename` function after `curl_mime_filedata` fixed the custom filename override

## example code for testing
```
session = Session(debug=True)
file = open(".python-version", "rb")
session.post("https://httpbin.org/post", files={"file":("f.txt",file)})
```

## result

### before fix
```
> POST /post HTTP/2
Host: httpbin.org
Accept-Encoding: gzip, deflate, br
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36
Content-Length: 214
Content-Type: multipart/form-data; boundary=------WebKitFormBoundarywxzexABQIe3iLmWU

> DATA --------WebKitFormBoundarywxzexABQIe3iLmWU
Content-Disposition: form-data; name="file"; filename=".python-version"
Content-Type: application/octet-stream

3.13.7

--------WebKitFormBoundarywxzexABQIe3iLmWU--
```

### after fix
```
> POST /post HTTP/2
Host: httpbin.org
Accept-Encoding: gzip, deflate, br
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36
Content-Length: 190
Content-Type: multipart/form-data; boundary=------WebKitFormBoundaryaMUEN51gFccytAsa

> DATA --------WebKitFormBoundaryaMUEN51gFccytAsa
Content-Disposition: form-data; name="file"; filename="f.txt"
Content-Type: text/plain

3.13.7

--------WebKitFormBoundaryaMUEN51gFccytAsa--
```