### PR TITLE
fix: use code2error mapping in stream exception paths (#744)

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -686,7 +686,8 @@ class Session(BaseSession[R]):
                         c, buffer, header_buffer, default_encoding, discard_cookies
                     )
                     rsp.request = req
-                    q.put_nowait(RequestException(str(e), e.code, rsp))  # type: ignore
+                    error_cls = code2error(e.code, str(e))
+                    q.put_nowait(error_cls(str(e), e.code, rsp))  # type: ignore
                 finally:
                     if not cast(threading.Event, header_recved).is_set():
                         cast(threading.Event, header_recved).set()
@@ -1297,7 +1298,8 @@ class AsyncSession(BaseSession[R]):
                         curl, buffer, header_buffer, default_encoding, discard_cookies
                     )
                     rsp.request = req
-                    q.put_nowait(RequestException(str(e), e.code, rsp))  # type: ignore
+                    error_cls = code2error(e.code, str(e))
+                    q.put_nowait(error_cls(str(e), e.code, rsp))  # type: ignore
                 finally:
                     if not cast(asyncio.Event, header_recved).is_set():
                         cast(asyncio.Event, header_recved).set()

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -11,7 +11,7 @@ import curl_cffi
 from curl_cffi import Curl, CurlFollow, CurlOpt, requests
 from curl_cffi.const import CurlECode, CurlInfo
 from curl_cffi.requests.errors import SessionClosed
-from curl_cffi.requests.exceptions import HTTPError
+from curl_cffi.requests.exceptions import HTTPError, IncompleteRead, TooManyRedirects
 from curl_cffi.requests.models import Response
 from curl_cffi.utils import CurlCffiWarning
 
@@ -912,6 +912,7 @@ def test_stream_incomplete_read(server):
                 for _ in r.iter_content():
                     continue
         assert e.value.code == CurlECode.PARTIAL_FILE
+        assert isinstance(e.value, IncompleteRead)
 
 
 def test_stream_incomplete_read_without_close(server):
@@ -925,6 +926,7 @@ def test_stream_incomplete_read_without_close(server):
                 continue
 
         assert e.value.code == CurlECode.PARTIAL_FILE
+        assert isinstance(e.value, IncompleteRead)
 
 
 def test_stream_redirect_loop(server):
@@ -934,6 +936,7 @@ def test_stream_redirect_loop(server):
             with s.stream("GET", url, max_redirects=2):
                 pass
         assert e.value.code == CurlECode.TOO_MANY_REDIRECTS
+        assert isinstance(e.value, TooManyRedirects)
         assert isinstance(e.value.response, Response)
         assert e.value.response.status_code == 301
 


### PR DESCRIPTION
## Problem

When a `CurlError` is raised during streaming (both sync and async), the exception is wrapped as a generic `RequestException` instead of being mapped to the appropriate subclass via `code2error()`. This means users get `RequestException` for DNS errors, SSL errors, timeouts, etc. when using `stream=True`, while the non-stream path correctly maps them to `DNSError`, `SSLError`, `Timeout`, etc.

Reported in #744.

## Root Cause

In both `Session._request_once()` (line 689) and `AsyncSession._request_once()` (line 1300), the stream `perform()` closure catches `CurlError` and wraps it directly:

```python
q.put_nowait(RequestException(str(e), e.code, rsp))
```

While the non-stream path correctly uses:

```python
error = code2error(e.code, str(e))
raise error(str(e), e.code, rsp) from e
```

## Fix

Replace `RequestException(...)` with `code2error(e.code, str(e))(...)` in both sync and async stream paths. This ensures the rich exception hierarchy (`DNSError`, `SSLError`, `Timeout`, `IncompleteRead`, `TooManyRedirects`, etc.) is used consistently in all code paths.

## Backward Compatibility

All specific exceptions inherit from `RequestException`, so existing `except RequestException` handlers still catch them. This is purely additive — users who want specific error handling in stream mode can now do so.

## Tests

- Added `isinstance` assertions to `test_stream_incomplete_read`, `test_stream_incomplete_read_without_close`, and `test_stream_redirect_loop` to verify specific exception types are raised in stream mode
- All 88 request tests pass (2 skipped for external deps)
- Full unit suite: 404 passed, 3 failed (smoke tests - network-dependent, unrelated to this change)