### PR TITLE
Fix cert compression setup order

### DIFF
--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -445,6 +445,12 @@ def _apply_fingerprint(
     if fingerprint.tls_ciphers:
         curl.setopt(CurlOpt.SSL_CIPHER_LIST, ":".join(fingerprint.tls_ciphers))
 
+    if fingerprint.tls_extension_order:
+        tls_extension_order = _strip_padding_extension(fingerprint.tls_extension_order)
+        extension_ids = set(int(e) for e in tls_extension_order.split("-"))
+        toggle_extensions_by_ids(curl, extension_ids)
+        curl.setopt(CurlOpt.TLS_EXTENSION_ORDER, tls_extension_order)
+
     curl.setopt(CurlOpt.SSL_ENABLE_ALPN, int(fingerprint.tls_alpn))
     curl.setopt(CurlOpt.SSL_ENABLE_ALPS, int(fingerprint.tls_alps))
     curl.setopt(CurlOpt.SSL_ENABLE_TICKET, int(fingerprint.tls_session_ticket))
@@ -478,12 +484,6 @@ def _apply_fingerprint(
             for group in fingerprint.tls_supported_groups
         ]
         curl.setopt(CurlOpt.SSL_EC_CURVES, ":".join(normalized_groups))
-
-    if fingerprint.tls_extension_order:
-        tls_extension_order = _strip_padding_extension(fingerprint.tls_extension_order)
-        extension_ids = set(int(e) for e in tls_extension_order.split("-"))
-        toggle_extensions_by_ids(curl, extension_ids)
-        curl.setopt(CurlOpt.TLS_EXTENSION_ORDER, tls_extension_order)
 
     if fingerprint.tls_delegated_credentials:
         curl.setopt(

--- a/tests/unittest/test_fingerprint_application.py
+++ b/tests/unittest/test_fingerprint_application.py
@@ -52,6 +52,23 @@ def test_apply_fingerprint_rewrites_kyber_supported_group_alias():
     assert curl.options[CurlOpt.SSL_EC_CURVES] == "X25519Kyber768Draft00:P-256"
 
 
+def test_apply_fingerprint_with_tls_extension_order_respects_cert_compression():
+    curl = FakeCurl()
+    fingerprint = Fingerprint(
+        tls_extension_order="0-23-65281-10-11-16-5-13-18-51-45-43-27",
+        tls_cert_compression=["zlib"],
+    )
+
+    _apply_fingerprint(
+        curl,
+        fingerprint,
+        existing_header_names=set(),
+        default_headers=False,
+    )
+
+    assert curl.options[CurlOpt.SSL_CERT_COMPRESSION] == "zlib"
+
+
 def test_apply_fingerprint_empty_host_uses_curl_generated_host():
     curl = FakeCurl()
     fingerprint = Fingerprint(


### PR DESCRIPTION
## Context

I have identified an issue when trying to implement a fingerprint with the new `Fingerprint` feature, turns out if you have defined `tls_extension_order` and `tls_cert_compression`, the first will overwrite `tls_cert_compression` by the default `brotli` defined when toggling `SSL_CERT_COMPRESSION`.

https://github.com/lexiforest/curl_cffi/blob/f04f33fe699a446f7fc8fe7ff21907c490577d0c/curl_cffi/requests/impersonate.py#L398-L408

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.