### PR TITLE
fix: prevent SIGSEGV when closing AsyncSession during active stream (#675)

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -341,9 +341,15 @@ class Response:
 
     async def aclose(self):
         """Close the streaming connection, only valid in stream mode."""
-
+        # Signal the perform coroutine to abort before awaiting it.
+        # Without this, SSE/long-lived streams never finish and aclose() hangs,
+        # and closing mid-stream without signaling can leave the curl handle in
+        # a partially-initialized state that crashes on cleanup (#675).
+        if self.quit_now:
+            self.quit_now.set()
         if self.astream_task:
-            await self.astream_task
+            with suppress(Exception):
+                await self.astream_task
 
     # It prints the status code of the response instead of the object's memory location.
     def __repr__(self) -> str:

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -981,8 +981,12 @@ class AsyncSession(BaseSession[R]):
 
     async def close(self) -> None:
         """Close the session."""
-        await self.acurl.close()
+        # Set _closed before closing the multi-handle so that any in-flight
+        # stream cleanup callbacks (release_curl) see the closed flag and call
+        # curl.close() instead of acurl.remove_handle() on an already-destroyed
+        # multi-handle, which would cause a segfault (#675).
         self._closed = True
+        await self.acurl.close()
         while True:
             try:
                 curl = self.pool.get_nowait()


### PR DESCRIPTION
## Problem

Two race conditions cause segfaults/hangs when AsyncSession.close() or Response.aclose() is called during an active streaming request.

### 1. AsyncSession.close() ordering race (SIGSEGV / SIGABRT)

_closed is set AFTER await self.acurl.close(). Between these two lines, the release_curl callback fires, sees _closed == False, and calls acurl.remove_handle() on the already-destroyed multi-handle.

### 2. Response.aclose() missing abort signal (hang + crash)

aclose() never sets quit_now before awaiting astream_task. For SSE streams, await self.astream_task hangs forever, and the curl handle is left in a partially-initialized state that crashes on cleanup.

## Fix

- session.py: Set self._closed = True BEFORE await self.acurl.close()
- models.py: Set quit_now event before awaiting stream task; suppress exceptions during await

## Related

Fixes #675

The Curl.reset = lambda self: None monkey-patch workaround documented in the issue confirms this root cause.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.