### PR TITLE
fix: apply fingerprint does not set passed http3 values

### DIFF
--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -528,12 +528,19 @@ def _apply_fingerprint(
     if fingerprint.http3_settings:
         curl.setopt(CurlOpt.HTTP3_SETTINGS, fingerprint.http3_settings)
     if fingerprint.http3_pseudo_headers_order:
-        curl.setopt(CurlOpt.HTTP3_PSEUDO_HEADERS_ORDER, fingerprint.http3_pseudo_headers_order.replace(",", ""))
+        curl.setopt(
+            CurlOpt.HTTP3_PSEUDO_HEADERS_ORDER,
+            fingerprint.http3_pseudo_headers_order.replace(",", ""),
+        )
     if fingerprint.http3_tls_extension_order:
-        curl.setopt(CurlOpt.HTTP3_TLS_EXTENSION_ORDER, fingerprint.http3_tls_extension_order)
+        curl.setopt(
+            CurlOpt.HTTP3_TLS_EXTENSION_ORDER, fingerprint.http3_tls_extension_order
+        )
     if fingerprint.quic_transport_parameters:
-        curl.setopt(CurlOpt.QUIC_TRANSPORT_PARAMETERS, fingerprint.quic_transport_parameters)
-    
+        curl.setopt(
+            CurlOpt.QUIC_TRANSPORT_PARAMETERS, fingerprint.quic_transport_parameters
+        )
+
     # default headers will not override user-defined headers
     if default_headers and fingerprint.headers:
         header_lines = []

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -524,6 +524,16 @@ def _apply_fingerprint(
     if fingerprint.form_boundary:
         curl.setopt(CurlOpt.FORM_BOUNDARY, fingerprint.form_boundary)
 
+    # http3 settings
+    if fingerprint.http3_settings:
+        curl.setopt(CurlOpt.HTTP3_SETTINGS, fingerprint.http3_settings)
+    if fingerprint.http3_pseudo_headers_order:
+        curl.setopt(CurlOpt.HTTP3_PSEUDO_HEADERS_ORDER, fingerprint.http3_pseudo_headers_order.replace(",", ""))
+    if fingerprint.http3_tls_extension_order:
+        curl.setopt(CurlOpt.HTTP3_TLS_EXTENSION_ORDER, fingerprint.http3_tls_extension_order)
+    if fingerprint.quic_transport_parameters:
+        curl.setopt(CurlOpt.QUIC_TRANSPORT_PARAMETERS, fingerprint.quic_transport_parameters)
+    
     # default headers will not override user-defined headers
     if default_headers and fingerprint.headers:
         header_lines = []

--- a/tests/unittest/test_setopt.py
+++ b/tests/unittest/test_setopt.py
@@ -137,9 +137,7 @@ def test_set_extra_fp_sets_extra_fingerprint_options():
     assert curl.options[CurlOpt.TLS_GREASE] == 1
     assert curl.options[CurlOpt.SSL_PERMUTE_EXTENSIONS] == 1
     assert curl.options[CurlOpt.SSL_CERT_COMPRESSION] == "zlib"
-    assert curl.options[CurlOpt.TLS_DELEGATED_CREDENTIALS] == (
-        "ecdsa_secp256r1_sha256"
-    )
+    assert curl.options[CurlOpt.TLS_DELEGATED_CREDENTIALS] == ("ecdsa_secp256r1_sha256")
     assert curl.options[CurlOpt.TLS_RECORD_SIZE_LIMIT] == 4001
     assert curl.options[CurlOpt.STREAM_WEIGHT] == 128
     assert curl.options[CurlOpt.STREAM_EXCLUSIVE] == 0


### PR DESCRIPTION
HTTP3 values are not set if using impersonate Fingerprint. They're only set if using perk string.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
