### PR TITLE
fix: add use_stdlib_json opt-out to Response.json() (#639)

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -13,11 +13,15 @@ from .cookies import Cookies
 from .exceptions import HTTPError, RequestException
 from .headers import Headers
 
-# Use orjson if present
+# Use orjson if present for performance; always keep stdlib json available so
+# callers can opt out via Response.json(use_stdlib_json=True). orjson does not
+# accept kwargs (see #639), so kwargs like parse_float= require the stdlib path.
+from json import loads as _stdlib_json_loads
+
 try:
     from orjson import loads
 except ImportError:
-    from json import loads
+    loads = _stdlib_json_loads
 
 with suppress(ImportError):
     from markdownify import markdownify as md
@@ -248,8 +252,22 @@ class Response:
             yield chunk
         self._finalize_stream()
 
-    def json(self, **kw):
-        """return a parsed json object of the content."""
+    def json(self, *, use_stdlib_json: bool = False, **kw):
+        """return a parsed json object of the content.
+
+        Args:
+            use_stdlib_json: When True, force ``json.loads`` from the standard
+                library instead of ``orjson.loads``. ``orjson`` is preferred for
+                performance but does not accept keyword arguments such as
+                ``parse_float=Decimal``; pass this flag whenever you need to
+                forward kwargs to the parser. No effect when ``orjson`` is not
+                installed (stdlib is already used). See #639.
+            **kw: Forwarded to the JSON loader. Only honoured by
+                ``json.loads``; using kwargs without ``use_stdlib_json=True``
+                while ``orjson`` is installed will raise ``TypeError``.
+        """
+        if use_stdlib_json:
+            return _stdlib_json_loads(self.content, **kw)
         return loads(self.content, **kw)
 
     def close(self):

--- a/tests/unittest/test_models.py
+++ b/tests/unittest/test_models.py
@@ -1,0 +1,83 @@
+"""Unit tests for ``curl_cffi.requests.models``.
+
+These tests construct ``Response`` directly without a server so they exercise
+pure-Python parsing helpers (e.g. ``Response.json``) in isolation.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from curl_cffi.requests.models import Response
+
+try:
+    import orjson  # noqa: F401
+
+    _HAS_ORJSON = True
+except ImportError:
+    _HAS_ORJSON = False
+
+
+def _make_response(content: bytes) -> Response:
+    r = Response()
+    r.content = content
+    return r
+
+
+def test_json_default_parses_content():
+    r = _make_response(b'{"foo": 1, "bar": "baz"}')
+    assert r.json() == {"foo": 1, "bar": "baz"}
+
+
+@pytest.mark.skipif(
+    not _HAS_ORJSON, reason="behavior under test only triggers when orjson is installed"
+)
+def test_json_kwargs_without_flag_raises_when_orjson_present():
+    """Forwarding kwargs without ``use_stdlib_json=True`` must still raise so
+    that existing call sites get a clear failure rather than silent behaviour
+    drift. See #639."""
+    r = _make_response(b'{"price": 1.5}')
+    with pytest.raises(TypeError):
+        r.json(parse_float=Decimal)
+
+
+def test_json_use_stdlib_json_true_accepts_kwargs():
+    """Opt-out flag forwards kwargs to ``json.loads`` and parses correctly."""
+    r = _make_response(b'{"price": 1.5}')
+    parsed = r.json(use_stdlib_json=True, parse_float=Decimal)
+    assert parsed == {"price": Decimal("1.5")}
+    assert isinstance(parsed["price"], Decimal)
+
+
+def test_json_use_stdlib_json_true_without_kwargs():
+    """Opt-out flag works on its own (no kwargs) — just exercises the stdlib
+    code path; result must match the default path."""
+    r = _make_response(b'{"foo": 1, "bar": "baz"}')
+    assert r.json(use_stdlib_json=True) == r.json()
+
+
+def test_json_use_stdlib_json_false_default_remains_orjson_path():
+    """Explicit ``use_stdlib_json=False`` reproduces the unchanged default,
+    which is the same instance ``orjson.loads`` (or stdlib if orjson is
+    missing). The output is identical to ``r.json()``."""
+    r = _make_response(b'{"foo": 1}')
+    assert r.json(use_stdlib_json=False) == r.json()
+
+
+@pytest.mark.parametrize(
+    "content,kwargs,expected",
+    [
+        (b'{"n": 1.5}', {"parse_float": Decimal}, {"n": Decimal("1.5")}),
+        (b'{"n": 100}', {"parse_int": float}, {"n": 100.0}),
+        (
+            b'{"n": 9999999999999999999}',
+            {"parse_int": str},
+            {"n": "9999999999999999999"},
+        ),
+    ],
+)
+def test_json_use_stdlib_json_forwards_supported_kwargs(content, kwargs, expected):
+    """``json.loads`` supports ``parse_float`` / ``parse_int`` / ``parse_constant``;
+    the opt-out path must forward them."""
+    r = _make_response(content)
+    assert r.json(use_stdlib_json=True, **kwargs) == expected


### PR DESCRIPTION
## Summary

`Response.json()` forwards `**kw` to the JSON loader, but when `orjson` is installed the module-level `loads` is bound to `orjson.loads`, which does not accept keyword arguments. So `r.json(parse_float=Decimal)` raises `TypeError: orjson.loads() takes no keyword arguments` while the same call works fine when `orjson` is not installed. Closes #639.

This adds a keyword-only `use_stdlib_json: bool = False` flag that forces `json.loads` from the standard library, matching the design called out in the issue thread (explicit opt-out, not auto-fallback). Default behaviour is unchanged — `orjson` is still preferred for the no-kwargs path.

## Reproduction

```python
from decimal import Decimal
from curl_cffi.requests.models import Response

r = Response(); r.content = b'{"price": 1.5}'
r.json(parse_float=Decimal)            # raises TypeError when orjson is installed
r.json(use_stdlib_json=True, parse_float=Decimal)
# {'price': Decimal('1.5')}              # works regardless of orjson presence
```

## Verification

- 8 unit tests in `tests/unittest/test_models.py` cover: default path, kwargs+orjson still raises (preserves existing semantics), opt-out works, opt-out without kwargs, plus three parametrized `parse_float` / `parse_int` cases.
- Differential 3-run on local install — with fix: PASS; fix reverted (subclass override): reproduces #639's `TypeError`; restored: PASS.
- `ruff check` and `ruff format --check` clean on the touched files.
- Existing 174 no-server unit tests + integration `test_response_class.py` and `test_httpbin.py` still pass on the branch.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.