### PR TITLE
fix: let per-request http_version override fingerprint default

### DIFF
--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -441,8 +441,9 @@ def _apply_fingerprint(
     fingerprint: Fingerprint,
     existing_header_names: set[str],
     default_headers: bool,
+    http_version_set: bool = False,
 ) -> None:
-    if fingerprint.http_version:
+    if fingerprint.http_version and not http_version_set:
         curl.setopt(
             CurlOpt.HTTP_VERSION, normalize_http_version(fingerprint.http_version)
         )
@@ -860,6 +861,7 @@ def set_curl_options(
             c.setopt(CurlOpt.SSLKEY, key)
 
     # http_version, before impersonation, which relies on checking if user wants http/3
+    http_version_set = bool(http_version)
     if http_version:
         http_version = normalize_http_version(http_version)
         c.setopt(CurlOpt.HTTP_VERSION, http_version)
@@ -867,7 +869,9 @@ def set_curl_options(
     # impersonate
     if impersonate:
         if isinstance(impersonate, Fingerprint):
-            _apply_fingerprint(c, impersonate, existing_header_names, default_headers)
+            _apply_fingerprint(
+                c, impersonate, existing_header_names, default_headers, http_version_set
+            )
         else:
             if _is_native_impersonate_target(impersonate):
                 normalized = resolve_latest_browser_type(impersonate)
@@ -883,7 +887,11 @@ def set_curl_options(
                         f"Impersonating {impersonate} is not supported"
                     )
                 _apply_fingerprint(
-                    c, fingerprint, existing_header_names, default_headers
+                    c,
+                    fingerprint,
+                    existing_header_names,
+                    default_headers,
+                    http_version_set,
                 )
 
     # ja3 string

--- a/tests/unittest/test_setopt.py
+++ b/tests/unittest/test_setopt.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from curl_cffi.const import CurlHttpVersion, CurlOpt, CurlSslVersion
+from curl_cffi.fingerprints import Fingerprint
 from curl_cffi.requests.impersonate import ExtraFingerprints
 from curl_cffi.requests import utils
 
@@ -158,6 +159,32 @@ def test_set_extra_fp_skips_unset_profile_defaults():
     utils.set_extra_fp(curl, extra_fp)
 
     assert curl.options == {CurlOpt.SSL_PERMUTE_EXTENSIONS: 1}
+
+
+@pytest.mark.parametrize(
+    "fingerprint, http_version, expected",
+    [
+        (Fingerprint(), "v3only", CurlHttpVersion.V3ONLY),
+        (Fingerprint(http_version="v3"), None, CurlHttpVersion.V3),
+    ],
+)
+def test_set_curl_options_http_version_precedence(fingerprint, http_version, expected):
+    curl = FakeCurl()
+
+    utils.set_curl_options(
+        curl,
+        "GET",
+        "https://example.com/",
+        params_list=[None, None],
+        headers_list=[None, None],
+        cookies_list=[None, None],
+        proxies_list=[None, None],
+        verify_list=[True, None],
+        impersonate=fingerprint,
+        http_version=http_version,
+    )
+
+    assert curl.options[CurlOpt.HTTP_VERSION] == expected
 
 
 def test_set_extra_fp_honors_explicit_false_and_zero_values():


### PR DESCRIPTION
Passing `http_version` per request gets ignored when you impersonate a Fingerprint.

`set_curl_options` sets the version you asked for, then `_apply_fingerprint` overwrites it with the Fingerprint's `http_version`, which defaults to `"v2"`. So `get(url, http_version="v3only", impersonate=Fingerprint(...))` quietly drops to HTTP/2.

Fix: the Fingerprint only sets the version when you didn't pass one yourself.

Added two tests. Checked live against cloudflare-quic.com: before, h2; after, h3.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
