### PR TITLE
fix: do not close an injected async_curl on session close

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -938,6 +938,7 @@ class AsyncSession(BaseSession[R]):
         super().__init__(**kwargs)
         self._loop: asyncio.AbstractEventLoop | None = loop
         self._acurl: AsyncCurl | None = async_curl
+        self._owns_acurl: bool = async_curl is None
         self.max_clients: int = max_clients
         self.init_pool()
 
@@ -981,7 +982,8 @@ class AsyncSession(BaseSession[R]):
 
     async def close(self) -> None:
         """Close the session."""
-        await self.acurl.close()
+        if self._owns_acurl:
+            await self.acurl.close()
         self._closed = True
         while True:
             try:

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 
 import pytest
 
-from curl_cffi import Headers
+from curl_cffi import AsyncCurl, Headers
 from curl_cffi.const import CurlECode
 from curl_cffi.requests import AsyncSession, RequestsError
 from curl_cffi.requests.errors import SessionClosed
@@ -505,3 +505,19 @@ async def test_async_session_auto_raise_for_status_disabled(server):
         r = await s.get(str(server.url.copy_with(path="/status/404")))
         assert r.status_code == 404
         # Should not raise an exception
+
+
+async def test_shared_async_curl_not_closed_by_session(server):
+    pool = AsyncCurl()
+
+    s1 = AsyncSession(async_curl=pool)
+    r1 = await s1.get(str(server.url))
+    assert r1.status_code == 200
+    await s1.close()
+
+    s2 = AsyncSession(async_curl=pool)
+    r2 = await s2.get(str(server.url))
+    assert r2.status_code == 200
+    await s2.close()
+
+    await pool.close()


### PR DESCRIPTION
`AsyncSession` already takes an `async_curl`, so in theory you can share one connection pool across sessions. It never worked though: `close()` always ran `curl_multi_cleanup` on the handle, even when you passed it in. So the first session to close killed the multi handle, and the next request on any sibling session crashed with `TypeError: initializer for ctype 'void *' must be a cdata pointer, not NoneType`.

Fix: only close the `AsyncCurl` when the session created it.

This lets separate sessions (isolated cookies/state) reuse one connection pool and one poller. Checked locally against a keep-alive server: six sequential requests across six sessions sharing one acurl reuse a single TCP connection (six without sharing), and closing each session no longer breaks the rest.

Added a regression test.

Came out of #641 — enables connection reuse with isolated sessions, though it's not a full fix for that issue on its own.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
