### PR TITLE
fix: release curl handle when set_curl_options raises

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -666,52 +666,59 @@ class Session(BaseSession[R]):
         else:
             c = self.curl
 
-        req, buffer, header_buffer, q, header_recved, quit_now = set_curl_options(
-            c,
-            method=method,
-            url=url,
-            params_list=[self.params, params],
-            base_url=self.base_url,
-            data=data,
-            json=json,
-            headers_list=[self.headers, headers],
-            cookies_list=[self._cookies, cookies],
-            files=files,
-            auth=auth or self.auth,
-            timeout=self.timeout if timeout is NOT_SET else timeout,
-            allow_redirects=(
-                self.allow_redirects if allow_redirects is None else allow_redirects
-            ),
-            max_redirects=(
-                self.max_redirects if max_redirects is None else max_redirects
-            ),
-            proxies_list=[self.proxies, proxies],
-            proxy=proxy,
-            proxy_auth=proxy_auth or self.proxy_auth,
-            verify_list=[self.verify, verify],
-            referer=referer,
-            accept_encoding=accept_encoding,
-            content_callback=content_callback,
-            impersonate=impersonate or self.impersonate,
-            ja3=ja3 or self.ja3,
-            akamai=akamai or self.akamai,
-            perk=perk or self.perk,
-            extra_fp=extra_fp or self.extra_fp,
-            default_headers=(
-                self.default_headers if default_headers is None else default_headers
-            ),
-            quote=quote,
-            http_version=http_version or self.http_version,
-            interface=interface or self.interface,
-            doh_url=doh_url or self.doh_url,
-            stream=stream,
-            max_recv_speed=max_recv_speed,
-            multipart=multipart,
-            cert=cert or self.cert,
-            curl_options=self.curl_options,
-            queue_class=queue.Queue,
-            event_class=threading.Event,
-        )
+        try:
+            req, buffer, header_buffer, q, header_recved, quit_now = set_curl_options(
+                c,
+                method=method,
+                url=url,
+                params_list=[self.params, params],
+                base_url=self.base_url,
+                data=data,
+                json=json,
+                headers_list=[self.headers, headers],
+                cookies_list=[self._cookies, cookies],
+                files=files,
+                auth=auth or self.auth,
+                timeout=self.timeout if timeout is NOT_SET else timeout,
+                allow_redirects=(
+                    self.allow_redirects if allow_redirects is None else allow_redirects
+                ),
+                max_redirects=(
+                    self.max_redirects if max_redirects is None else max_redirects
+                ),
+                proxies_list=[self.proxies, proxies],
+                proxy=proxy,
+                proxy_auth=proxy_auth or self.proxy_auth,
+                verify_list=[self.verify, verify],
+                referer=referer,
+                accept_encoding=accept_encoding,
+                content_callback=content_callback,
+                impersonate=impersonate or self.impersonate,
+                ja3=ja3 or self.ja3,
+                akamai=akamai or self.akamai,
+                perk=perk or self.perk,
+                extra_fp=extra_fp or self.extra_fp,
+                default_headers=(
+                    self.default_headers if default_headers is None else default_headers
+                ),
+                quote=quote,
+                http_version=http_version or self.http_version,
+                interface=interface or self.interface,
+                doh_url=doh_url or self.doh_url,
+                stream=stream,
+                max_recv_speed=max_recv_speed,
+                multipart=multipart,
+                cert=cert or self.cert,
+                curl_options=self.curl_options,
+                queue_class=queue.Queue,
+                event_class=threading.Event,
+            )
+        except (CurlError, TypeError, NotImplementedError):
+            if stream:
+                c.close()
+            else:
+                c.reset()
+            raise
 
         if self._cache_enabled(req, stream=stream, content_callback=content_callback):
             cached_response = self.cache.get(
@@ -1342,52 +1349,56 @@ class AsyncSession(BaseSession[R]):
         discard_cookies: bool = False,
     ) -> R:
         curl = await self.pop_curl()
-        req, buffer, header_buffer, q, header_recved, quit_now = set_curl_options(
-            curl=curl,
-            method=method,
-            url=url,
-            params_list=[self.params, params],
-            base_url=self.base_url,
-            data=data,
-            json=json,
-            headers_list=[self.headers, headers],
-            cookies_list=[self.cookies, cookies],
-            files=files,
-            auth=auth or self.auth,
-            timeout=self.timeout if timeout is NOT_SET else timeout,
-            allow_redirects=(
-                self.allow_redirects if allow_redirects is None else allow_redirects
-            ),
-            max_redirects=(
-                self.max_redirects if max_redirects is None else max_redirects
-            ),
-            proxies_list=[self.proxies, proxies],
-            proxy=proxy,
-            proxy_auth=proxy_auth or self.proxy_auth,
-            verify_list=[self.verify, verify],
-            referer=referer,
-            accept_encoding=accept_encoding,
-            content_callback=content_callback,
-            impersonate=impersonate or self.impersonate,
-            ja3=ja3 or self.ja3,
-            akamai=akamai or self.akamai,
-            perk=perk or self.perk,
-            extra_fp=extra_fp or self.extra_fp,
-            default_headers=(
-                self.default_headers if default_headers is None else default_headers
-            ),
-            quote=quote,
-            http_version=http_version or self.http_version,
-            interface=interface or self.interface,
-            doh_url=doh_url or self.doh_url,
-            stream=stream,
-            max_recv_speed=max_recv_speed,
-            multipart=multipart,
-            cert=cert or self.cert,
-            curl_options=self.curl_options,
-            queue_class=asyncio.Queue,
-            event_class=asyncio.Event,
-        )
+        try:
+            req, buffer, header_buffer, q, header_recved, quit_now = set_curl_options(
+                curl=curl,
+                method=method,
+                url=url,
+                params_list=[self.params, params],
+                base_url=self.base_url,
+                data=data,
+                json=json,
+                headers_list=[self.headers, headers],
+                cookies_list=[self.cookies, cookies],
+                files=files,
+                auth=auth or self.auth,
+                timeout=self.timeout if timeout is NOT_SET else timeout,
+                allow_redirects=(
+                    self.allow_redirects if allow_redirects is None else allow_redirects
+                ),
+                max_redirects=(
+                    self.max_redirects if max_redirects is None else max_redirects
+                ),
+                proxies_list=[self.proxies, proxies],
+                proxy=proxy,
+                proxy_auth=proxy_auth or self.proxy_auth,
+                verify_list=[self.verify, verify],
+                referer=referer,
+                accept_encoding=accept_encoding,
+                content_callback=content_callback,
+                impersonate=impersonate or self.impersonate,
+                ja3=ja3 or self.ja3,
+                akamai=akamai or self.akamai,
+                perk=perk or self.perk,
+                extra_fp=extra_fp or self.extra_fp,
+                default_headers=(
+                    self.default_headers if default_headers is None else default_headers
+                ),
+                quote=quote,
+                http_version=http_version or self.http_version,
+                interface=interface or self.interface,
+                doh_url=doh_url or self.doh_url,
+                stream=stream,
+                max_recv_speed=max_recv_speed,
+                multipart=multipart,
+                cert=cert or self.cert,
+                curl_options=self.curl_options,
+                queue_class=asyncio.Queue,
+                event_class=asyncio.Event,
+            )
+        except (CurlError, TypeError, NotImplementedError):
+            self.release_curl(curl)
+            raise
         if stream:
             task = self.acurl.add_handle(curl)
             curl_released = False

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -521,3 +521,13 @@ async def test_shared_async_curl_not_closed_by_session(server):
     await s2.close()
 
     await pool.close()
+
+
+async def test_set_curl_options_error_releases_curl(server):
+    async with AsyncSession(max_clients=1) as s:
+        url = str(server.url)
+        for _ in range(3):
+            with pytest.raises(TypeError):
+                await s.post(url, data=object())  # type: ignore[arg-type]
+        r = await asyncio.wait_for(s.get(url), timeout=5)
+        assert r.status_code == 200

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -1088,3 +1088,13 @@ def test_session_auto_raise_for_status_disabled(server):
     r = s.get(str(server.url.copy_with(path="/status/404")))
     assert r.status_code == 404
     # Should not raise an exception
+
+
+def test_set_curl_options_error_does_not_break_session(server):
+    with requests.Session() as s:
+        url = str(server.url)
+        for _ in range(3):
+            with pytest.raises(TypeError):
+                s.post(url, data=object())  # type: ignore[arg-type]
+        r = s.get(url)
+        assert r.status_code == 200


### PR DESCRIPTION
`set_curl_options` runs after the handle is popped from the pool, but before the `try/finally` that releases it. If it raises (bad data/header type, unsupported option, encoding error), the handle never goes back.

In `AsyncSession` that drains the pool one handle per failed request. Once empty, `pop_curl` waits on `pool.get()` forever and the session freezes. That's #681. Sync path leaks the dup'd handle on streaming and leaves `self.curl` dirty otherwise.

Fix: wrap the call. On error async releases the handle, sync resets `self.curl` (or closes the streaming duphandle), then re-raises.

Test for both sync and async: a few requests that fail inside `set_curl_options` on a `max_clients=1` session, then a normal request must still work. Without the fix the async one hangs.

Fixes #681.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
