### PR TITLE
fix: bind bare IP passed to interface as local source address

### DIFF
--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -125,7 +125,7 @@ def request(
         curl_options: extra curl options to use.
         http_version: limiting http version, defaults to http2.
         debug: print extra curl debug info.
-        interface: which interface to use.
+        interface: interface name or local IP to bind to (bare IP = source address).
         cert: a tuple of (cert, key) filenames for client cert.
         stream: streaming the response, default False.
         max_recv_speed: maximum receive speed, bytes per second.

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -451,7 +451,7 @@ class Session(BaseSession[R]):
             akamai: akamai string to impersonate in the session.
             perk: perk string to impersonate in the session.
             extra_fp: extra fingerprints options, in complement to ja3 and akamai str.
-            interface: which interface use.
+            interface: interface name or local IP to bind to (bare IP = source address).
             default_encoding: encoding for decoding response content if charset is not
                 found in headers. Defaults to "utf-8". Can be set to a callable for
                 automatic detection.
@@ -1094,7 +1094,7 @@ class AsyncSession(BaseSession[R]):
                 url will be kept as is, without any automatic percent-encoding, you must
                 encode the URL yourself.
             http_version: limiting http version, defaults to http2.
-            interface: which interface to use.
+            interface: interface name or local IP to bind to (bare IP = source address).
             cert: a tuple of (cert, key) filenames for client cert.
             max_recv_speed: maximum receive speed, bytes per second.
             recv_queue_size: The maximum number of incoming WebSocket

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -4,6 +4,7 @@ __all__ = ["HttpVersionLiteral", "set_curl_options", "NOT_SET"]
 
 
 import asyncio
+import ipaddress
 import math
 import queue
 import warnings
@@ -960,7 +961,15 @@ def set_curl_options(
 
     # interface
     if interface:
-        c.setopt(CurlOpt.INTERFACE, interface.encode())
+        value = interface
+        if "!" not in interface:
+            try:
+                ipaddress.ip_address(interface)
+            except ValueError:
+                pass
+            else:
+                value = f"host!{interface}"
+        c.setopt(CurlOpt.INTERFACE, value.encode())
 
     # max_recv_speed
     # do not check, since 0 is a valid value to disable it

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -365,7 +365,7 @@ class WebSocket(BaseWebSocket):
                 will be removed from the safe string. If set to ``False``, the URL
                 is used as-is (you must encode it yourself).
             http_version: Limiting http version, defaults to http2.
-            interface: which interface to use.
+            interface: interface name or local IP to bind to (bare IP = source address).
             cert: a tuple of (cert, key) filenames for client cert.
             max_recv_speed: maximum receive speed, bytes per second.
             curl_options: extra curl options to use.

--- a/tests/unittest/test_setopt.py
+++ b/tests/unittest/test_setopt.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+import pytest
+
 from curl_cffi.const import CurlHttpVersion, CurlOpt, CurlSslVersion
 from curl_cffi.requests.impersonate import ExtraFingerprints
 from curl_cffi.requests import utils
@@ -171,3 +173,39 @@ def test_set_extra_fp_honors_explicit_false_and_zero_values():
     assert curl.options[CurlOpt.TLS_GREASE] == 0
     assert curl.options[CurlOpt.SSL_PERMUTE_EXTENSIONS] == 0
     assert curl.options[CurlOpt.STREAM_EXCLUSIVE] == 0
+
+
+def _set_interface(interface):
+    curl = FakeCurl()
+    utils.set_curl_options(
+        curl,
+        "GET",
+        "https://example.com/",
+        params_list=[None, None],
+        headers_list=[None, None],
+        cookies_list=[None, None],
+        proxies_list=[None, None],
+        verify_list=[True, None],
+        interface=interface,
+    )
+    return curl
+
+
+@pytest.mark.parametrize(
+    "interface,expected",
+    [
+        ("192.0.2.10", b"host!192.0.2.10"),
+        ("2001:db8::1", b"host!2001:db8::1"),
+    ],
+)
+def test_interface_bare_ip_gets_host_prefix(interface, expected):
+    curl = _set_interface(interface)
+
+    assert curl.options[CurlOpt.INTERFACE] == expected
+
+
+@pytest.mark.parametrize("interface", ["eth0", "host!192.0.2.10"])
+def test_interface_name_and_prefixed_values_pass_through(interface):
+    curl = _set_interface(interface)
+
+    assert curl.options[CurlOpt.INTERFACE] == interface.encode()


### PR DESCRIPTION
Binding a bare IP via `interface=` broke in 0.14.0b5: libcurl 8.15.0 no longer treats a bare IP given to `CURLOPT_INTERFACE` as a local source address, so it fails with `Couldn't bind to '[...]'`. Prefix a bare IP with `host!` so it is bound as a source address; interface names and explicit `if!`/`host!` values are left untouched.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.

Close #670
