### PR TITLE
feat: add CurlShare to share DNS/TLS caches across session threads

### DIFF
--- a/curl_cffi/__init__.py
+++ b/curl_cffi/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     "Curl",
     "AsyncCurl",
     "CurlMime",
+    "CurlShare",
     "CurlError",
     "CurlInfo",
     "CurlOpt",
@@ -11,6 +12,10 @@ __all__ = [
     "CurlFollow",
     "CurlSslVersion",
     "CurlWsFlag",
+    "CurlSHOpt",
+    "CurlLockData",
+    "CurlLockAccess",
+    "CurlSHCode",
     "config_warnings",
     "Fingerprint",
     "FingerprintManager",
@@ -61,12 +66,16 @@ from .const import (
     CurlFollow,
     CurlHttpVersion,
     CurlInfo,
+    CurlLockAccess,
+    CurlLockData,
     CurlMOpt,
     CurlOpt,
+    CurlSHCode,
+    CurlSHOpt,
     CurlSslVersion,
     CurlWsFlag,
 )
-from .curl import Curl, CurlError, CurlMime
+from .curl import Curl, CurlError, CurlMime, CurlShare
 
 from .requests import (
     AsyncSession,

--- a/curl_cffi/const.py
+++ b/curl_cffi/const.py
@@ -627,3 +627,47 @@ class CurlFollow(IntEnum):
     # curl-impersonate: Follow redirects, but reject redirects to
     # internal/private IP addresses (SSRF protection)
     SAFE = 4
+
+
+class CurlSHOpt(IntEnum):
+    """``CURLSHOPT_`` constants from libcurl,
+    see: https://curl.se/libcurl/c/curl_share_setopt.html"""
+
+    NONE = 0
+    SHARE = 1
+    UNSHARE = 2
+    LOCKFUNC = 3
+    UNLOCKFUNC = 4
+    USERDATA = 5
+
+
+class CurlLockData(IntEnum):
+    """``CURL_LOCK_DATA_`` constants from libcurl, the data a share may hold."""
+
+    NONE = 0
+    SHARE = 1
+    COOKIE = 2
+    DNS = 3
+    SSL_SESSION = 4
+    CONNECT = 5
+    PSL = 6
+    HSTS = 7
+
+
+class CurlLockAccess(IntEnum):
+    """``CURL_LOCK_ACCESS_`` constants passed to the share lock callback."""
+
+    NONE = 0
+    SHARED = 1
+    SINGLE = 2
+
+
+class CurlSHCode(IntEnum):
+    """``CURLSHE_`` return codes from ``curl_share_*`` functions."""
+
+    OK = 0
+    BAD_OPTION = 1
+    IN_USE = 2
+    INVALID = 3
+    NOMEM = 4
+    NOT_BUILT_IN = 5

--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -5,6 +5,7 @@ import re
 import struct
 import ssl
 import sys
+import threading
 import warnings
 from http.cookies import SimpleCookie
 from pathlib import Path
@@ -15,7 +16,16 @@ import os
 import certifi
 
 from ._wrapper import ffi, lib
-from .const import CurlECode, CurlHttpVersion, CurlInfo, CurlOpt, CurlWsFlag
+from .const import (
+    CurlECode,
+    CurlHttpVersion,
+    CurlInfo,
+    CurlLockData,
+    CurlOpt,
+    CurlSHCode,
+    CurlSHOpt,
+    CurlWsFlag,
+)
 from .utils import CurlCffiWarning
 
 
@@ -196,6 +206,24 @@ def read_callback(ptr, size, nmemb, userdata):
     return len(data)
 
 
+@ffi.def_extern()
+def lock_function(handle, data, access, userptr):
+    """ffi callback for ``curl_lock_function``, acquires the per-data mutex."""
+    locks = ffi.from_handle(userptr)
+    lock = locks.get(data)
+    if lock is not None:
+        lock.acquire()
+
+
+@ffi.def_extern()
+def unlock_function(handle, data, userptr):
+    """ffi callback for ``curl_unlock_function``, releases the per-data mutex."""
+    locks = ffi.from_handle(userptr)
+    lock = locks.get(data)
+    if lock is not None:
+        lock.release()
+
+
 # Credits: @alexio777 on https://github.com/lexiforest/curl_cffi/issues/4
 def slist_to_list(head) -> list[bytes]:
     """Converts curl slist to a python list."""
@@ -237,6 +265,7 @@ class Curl:
         # TODO: use CURL_ERROR_SIZE
         self._error_buffer = ffi.new("char[]", 256)
         self._debug = debug
+        self._share: CurlShare | None = None
         self._set_error_buffer()
 
         # Pre-allocated CFFI objects for WebSocket performance
@@ -546,6 +575,10 @@ class Curl:
             raise CurlError("Cannot duplicate closed handle.")
         new_handle = lib.curl_easy_duphandle(self._curl)
         c = Curl(cacert=self._cacert, debug=self._debug, handle=new_handle)
+        # duphandle does not inherit CURLOPT_SHARE, so re-attach it.
+        if self._share is not None:
+            c.setopt(CurlOpt.SHARE, self._share._curl_share)
+            c._share = self._share
         return c
 
     def reset(self) -> None:
@@ -688,6 +721,77 @@ class Curl:
         """
         payload = struct.pack("!H", code) + message
         return self.ws_send(payload, flags=CurlWsFlag.CLOSE)
+
+
+class CurlShare:
+    """Wrapper for the ``curl_share_*`` API."""
+
+    def __init__(
+        self,
+        connect: bool = False,
+        dns: bool = True,
+        ssl_session: bool = True,
+    ) -> None:
+        """
+        Parameters:
+            connect: share the connection cache. Only safe for serialized,
+                single-threaded use; libcurl does not support sharing
+                connections between concurrent threads.
+            dns: share the DNS cache.
+            ssl_session: share the TLS session cache.
+        """
+        self._closed = False
+        self._curl_share = lib.curl_share_init()
+        if not self._curl_share:
+            raise CurlError(
+                "Failed to create share handle, curl_share_init returned NULL"
+            )
+        # Pass the lock table (not self) as userdata to avoid a reference cycle.
+        self._locks: dict[int, threading.Lock] = {
+            int(data): threading.Lock() for data in CurlLockData
+        }
+        self._userdata = ffi.new_handle(self._locks)
+        self._setopt(CurlSHOpt.LOCKFUNC, ffi.cast("void *", lib.lock_function))
+        self._setopt(CurlSHOpt.UNLOCKFUNC, ffi.cast("void *", lib.unlock_function))
+        self._setopt(CurlSHOpt.USERDATA, self._userdata)
+        if connect:
+            self.share(CurlLockData.CONNECT)
+        if dns:
+            self.share(CurlLockData.DNS)
+        if ssl_session:
+            self.share(CurlLockData.SSL_SESSION)
+
+    def _setopt(self, option: CurlSHOpt, value: Any) -> None:
+        if option in (CurlSHOpt.SHARE, CurlSHOpt.UNSHARE):
+            c_value = ffi.new("int *", value)
+        else:
+            c_value = value
+        code = lib._curl_share_setopt(self._curl_share, option, c_value)
+        if code != CurlSHCode.OK:
+            errmsg = ffi.string(lib.curl_share_strerror(code)).decode()
+            raise CurlError(f"Failed to set share option {option}: {errmsg}", code=code)
+
+    def share(self, data: CurlLockData) -> None:
+        """Start sharing the given ``CurlLockData`` across attached handles."""
+        self._setopt(CurlSHOpt.SHARE, data)
+
+    def unshare(self, data: CurlLockData) -> None:
+        """Stop sharing the given ``CurlLockData``."""
+        self._setopt(CurlSHOpt.UNSHARE, data)
+
+    def close(self) -> None:
+        """Cleanup the share handle, wrapper for ``curl_share_cleanup``.
+
+        Only call this once every attached easy handle has been closed,
+        otherwise libcurl refuses to free a share still in use.
+        """
+        if not self._closed and self._curl_share:
+            lib.curl_share_cleanup(self._curl_share)
+            self._closed = True
+            self._curl_share = None
+
+    def __del__(self) -> None:
+        self.close()
 
 
 class CurlMime:

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -36,7 +36,7 @@ except ImportError:
 
 from ..aio import AsyncCurl
 from ..const import CurlFollow, CurlHttpVersion, CurlInfo, CurlOpt
-from ..curl import Curl, CurlError, CurlMime
+from ..curl import Curl, CurlError, CurlMime, CurlShare
 from ..utils import CurlCffiWarning
 from .cache import CacheSpec, normalize_cache_backend
 from .cookies import Cookies, CookieTypes, CurlMorsel
@@ -299,6 +299,7 @@ class BaseSession(Generic[R]):
             raise ValueError("You need to provide an absolute url for 'base_url'")
 
         self._closed = False
+        self._share: Optional[CurlShare] = None
         # Look for requests environment configuration
         # and be compatible with cURL.
         if self.verify is True or self.verify is None:
@@ -307,6 +308,11 @@ class BaseSession(Generic[R]):
                 or os.environ.get("CURL_CA_BUNDLE")
                 or self.verify
             )
+
+    def _attach_share(self, curl: Curl) -> None:
+        if self._share is not None:
+            curl.setopt(CurlOpt.SHARE, self._share._curl_share)
+            curl._share = self._share  # keep the share alive while in use
 
     def _parse_response(
         self,
@@ -443,6 +449,7 @@ class Session(BaseSession[R]):
         curl: Optional[Curl] = None,
         thread: Optional[ThreadType] = None,
         use_thread_local_curl: bool = True,
+        curl_share: Optional[CurlShare] = None,
         **kwargs: Unpack[BaseSessionParams[R]],
     ) -> None:
         """
@@ -455,6 +462,9 @@ class Session(BaseSession[R]):
                 from another thread.
             thread: thread engine to use for working with other thread implementations.
                 choices: eventlet, gevent.
+            curl_share: a ``CurlShare`` attached to every (thread-local) handle,
+                to share the DNS and TLS session caches across threads. See the
+                note in the docs on connection reuse across threads.
             headers: headers to use in the session.
             cookies: cookies to add in the session.
             auth: HTTP basic auth, a tuple of (username, password), only basic auth is
@@ -506,6 +516,7 @@ class Session(BaseSession[R]):
         self._use_thread_local_curl = use_thread_local_curl
         self._queue = None
         self._executor = None
+        self._share = curl_share
         if use_thread_local_curl:
             self._local = threading.local()
             if curl:
@@ -514,8 +525,10 @@ class Session(BaseSession[R]):
             else:
                 self._is_customized_curl = False
                 self._local.curl = Curl(debug=self.debug)
+            self._attach_share(self._local.curl)
         else:
             self._curl = curl if curl else Curl(debug=self.debug)
+            self._attach_share(self._curl)
 
     @property
     def curl(self):
@@ -528,6 +541,7 @@ class Session(BaseSession[R]):
                 )
             if not getattr(self._local, "curl", None):
                 self._local.curl = Curl(debug=self.debug)
+                self._attach_share(self._local.curl)
             return self._local.curl
         else:
             return self._curl
@@ -929,6 +943,7 @@ class AsyncSession(BaseSession[R]):
         loop: asyncio.AbstractEventLoop | None = None,
         async_curl: AsyncCurl | None = None,
         max_clients: int = 10,
+        curl_share: Optional[CurlShare] = None,
         **kwargs: Unpack[BaseSessionParams[R]],
     ) -> None:
         """
@@ -940,6 +955,8 @@ class AsyncSession(BaseSession[R]):
             async_curl: [AsyncCurl](/api/curl_cffi#curl_cffi.AsyncCurl) object to use.
             max_clients: maxmium curl handle to use in the session,
                 this will affect the concurrency ratio.
+            curl_share: a ``CurlShare`` attached to every pooled handle, to share
+                the DNS and TLS session caches across the handles in the pool.
             headers: headers to use in the session.
             cookies: cookies to add in the session.
             auth: HTTP basic auth, a tuple of (username, password), only basic auth is
@@ -1000,6 +1017,7 @@ class AsyncSession(BaseSession[R]):
         self._acurl: AsyncCurl | None = async_curl
         self._owns_acurl: bool = async_curl is None
         self.max_clients: int = max_clients
+        self._share = curl_share
         self.init_pool()
 
     @property
@@ -1027,6 +1045,7 @@ class AsyncSession(BaseSession[R]):
         curl: Curl | None = await self.pool.get()
         if curl is None:
             curl = Curl(cacert=self.acurl._cacert, debug=self.debug)
+            self._attach_share(curl)
         return curl
 
     def push_curl(self, curl: Curl | None) -> None:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -257,3 +257,37 @@ With http/2, you can optionally send a ping frame to keep the connection alive w
    async with AsyncSession() as s:
        await s.get("https://example.com")
        await s.upkeep()
+
+
+Connection reuse across threads
+===============================
+
+A synchronous ``Session`` keeps one curl handle per thread (``use_thread_local_curl``,
+on by default), because a curl handle is not safe to use from several threads at once.
+The connection pool lives inside each handle, so connections — and options that act on
+the pool such as ``MAXCONNECTS`` — are only reused *within* a thread. Reusing the same
+``Session`` from a thread pool therefore opens at least one connection per thread.
+
+libcurl does **not** support sharing the connection cache between concurrent threads,
+so there is no safe way to pool the actual connections across the thread-local handles.
+If you need real connection reuse across workers, use one ``Session`` per worker, or the
+``AsyncSession``, whose connections are shared within its event loop.
+
+What you *can* share across threads is the DNS cache and the TLS session cache, which
+cuts the cost of reconnecting to the same host (DNS lookups and TLS handshakes). Pass a
+``CurlShare`` to the session:
+
+.. code-block:: python
+
+   from curl_cffi import CurlShare, Session
+
+   share = CurlShare()  # shares DNS + TLS sessions, safe across threads
+   with Session(curl_share=share) as s:
+       s.get("https://example.com")
+
+The share is attached to every handle the session creates, including the ones used for
+streaming and WebSocket responses. ``AsyncSession`` accepts the same ``curl_share=``
+argument, sharing the DNS and TLS caches across the handles in its pool.
+
+``CurlShare`` can also share the connection cache (``CurlShare(connect=True)``), but that
+is only safe when the handles are used serially, never from multiple concurrent threads.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -52,6 +52,16 @@ CurlMime
    .. automethod:: attach
    .. automethod:: close
 
+CurlShare
+~~~~~~~~~
+
+.. autoclass:: curl_cffi.CurlShare
+
+   .. automethod:: __init__
+   .. automethod:: share
+   .. automethod:: unshare
+   .. automethod:: close
+
 Constants
 ~~~~~~~~~
 

--- a/ffi/cdef.c
+++ b/ffi/cdef.c
@@ -54,6 +54,16 @@ struct CURLMsg *curl_multi_info_read(void* curlm, int *msg_in_queue);
 extern "Python" int socket_function(void *curl, int sockfd, int what, void *clientp, void *socketp);
 extern "Python" int timer_function(void *curlm, int timeout_ms, void *clientp);
 
+// share interfaces
+void *curl_share_init();
+int _curl_share_setopt(void *share, int option, void *param);
+int curl_share_cleanup(void *share);
+const char *curl_share_strerror(int code);
+
+// share callbacks
+extern "Python" void lock_function(void *handle, int data, int access, void *userptr);
+extern "Python" void unlock_function(void *handle, int data, void *userptr);
+
 // websocket
 struct curl_ws_frame {
   int age;              /* zero */

--- a/ffi/shim.c
+++ b/ffi/shim.c
@@ -16,3 +16,11 @@ int _curl_easy_setopt(void* curl, int option, void* parameter) {
     }
     return (int)curl_easy_setopt(curl, (CURLoption)option, parameter);
 }
+
+int _curl_share_setopt(void* share, int option, void* parameter) {
+    // SHARE/UNSHARE read an int via va_arg; callbacks and userdata are pointers.
+    if (option == CURLSHOPT_SHARE || option == CURLSHOPT_UNSHARE) {
+        return (int)curl_share_setopt((CURLSH*)share, (CURLSHoption)option, *(int*)parameter);
+    }
+    return (int)curl_share_setopt((CURLSH*)share, (CURLSHoption)option, parameter);
+}

--- a/ffi/shim.h
+++ b/ffi/shim.h
@@ -5,3 +5,4 @@
 #include "curl/curl.h"
 
 int _curl_easy_setopt(void* curl, int option, void* param);
+int _curl_share_setopt(void* share, int option, void* param);

--- a/scripts/generate_consts.py
+++ b/scripts/generate_consts.py
@@ -135,5 +135,49 @@ class CurlFollow(IntEnum):
     # curl-impersonate: Follow redirects, but reject redirects to
     # internal/private IP addresses (SSRF protection)
     SAFE = 4
+
+
+class CurlSHOpt(IntEnum):
+    """``CURLSHOPT_`` constants from libcurl,
+    see: https://curl.se/libcurl/c/curl_share_setopt.html"""
+
+    NONE = 0
+    SHARE = 1
+    UNSHARE = 2
+    LOCKFUNC = 3
+    UNLOCKFUNC = 4
+    USERDATA = 5
+
+
+class CurlLockData(IntEnum):
+    """``CURL_LOCK_DATA_`` constants from libcurl, the data a share may hold."""
+
+    NONE = 0
+    SHARE = 1
+    COOKIE = 2
+    DNS = 3
+    SSL_SESSION = 4
+    CONNECT = 5
+    PSL = 6
+    HSTS = 7
+
+
+class CurlLockAccess(IntEnum):
+    """``CURL_LOCK_ACCESS_`` constants passed to the share lock callback."""
+
+    NONE = 0
+    SHARED = 1
+    SINGLE = 2
+
+
+class CurlSHCode(IntEnum):
+    """``CURLSHE_`` return codes from ``curl_share_*`` functions."""
+
+    OK = 0
+    BAD_OPTION = 1
+    IN_USE = 2
+    INVALID = 3
+    NOMEM = 4
+    NOT_BUILT_IN = 5
 '''
     )

--- a/tests/unittest/test_share.py
+++ b/tests/unittest/test_share.py
@@ -1,0 +1,102 @@
+import threading
+from io import BytesIO
+
+from curl_cffi import Curl, CurlInfo, CurlLockData, CurlOpt, CurlShare, Session
+
+
+def test_curl_share_lifecycle():
+    share = CurlShare()
+    share.share(CurlLockData.COOKIE)
+    share.unshare(CurlLockData.COOKIE)
+    share.close()
+    share.close()  # idempotent
+
+
+def test_share_enables_cross_handle_connection_reuse(server):
+    # connect sharing is only safe serialized: two handles, same thread.
+    url = str(server.url)
+    share = CurlShare(connect=True)
+
+    def fetch(curl: Curl) -> int:
+        curl.setopt(CurlOpt.URL, url.encode())
+        curl.setopt(CurlOpt.SHARE, share._curl_share)
+        curl.setopt(CurlOpt.WRITEDATA, BytesIO())
+        curl.perform()
+        num_connects = curl.getinfo(CurlInfo.NUM_CONNECTS)
+        assert isinstance(num_connects, int)
+        return num_connects
+
+    first, second = Curl(), Curl()
+    try:
+        assert fetch(first) == 1  # opens a connection
+        assert fetch(second) == 0  # reuses it from the shared cache
+    finally:
+        first.close()
+        second.close()
+        share.close()
+
+
+def test_share_survives_reset(server):
+    # The Session resets its handle after every request, so CURLOPT_SHARE must
+    # survive curl_easy_reset; otherwise sharing would only work for the first
+    # request on each handle.
+    url = str(server.url)
+    share = CurlShare(connect=True)
+
+    def fetch(curl: Curl) -> int:
+        curl.setopt(CurlOpt.URL, url.encode())
+        curl.setopt(CurlOpt.WRITEDATA, BytesIO())
+        curl.perform()
+        num_connects = curl.getinfo(CurlInfo.NUM_CONNECTS)
+        assert isinstance(num_connects, int)
+        return num_connects
+
+    first, second = Curl(), Curl()
+    try:
+        first.setopt(CurlOpt.SHARE, share._curl_share)
+        assert fetch(first) == 1  # opens a connection
+        second.setopt(CurlOpt.SHARE, share._curl_share)
+        second.reset()  # clears options, but must keep the share attached
+        assert fetch(second) == 0  # still reuses the shared connection
+    finally:
+        first.close()
+        second.close()
+        share.close()
+
+
+def test_session_threaded_requests_with_share(server):
+    url = str(server.url)
+    results: list[int] = []
+    errors: list[Exception] = []
+
+    # default CurlShare shares only DNS + TLS sessions: safe across threads.
+    with Session(curl_share=CurlShare()) as s:
+
+        def worker() -> None:
+            try:
+                for _ in range(5):
+                    results.append(s.get(url).status_code)
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert not errors
+    assert len(results) == 40
+    assert all(code == 200 for code in results)
+
+
+def test_share_reattached_to_streaming_handle(server):
+    # A streamed request runs on a duphandle()'d handle, which does not inherit
+    # CURLOPT_SHARE, so the session must re-attach the share to it.
+    share = CurlShare()
+    with Session(curl_share=share) as s:
+        r = s.get(str(server.url), stream=True)
+        try:
+            assert r.curl is not None and r.curl._share is share
+        finally:
+            r.close()


### PR DESCRIPTION
Adds `CurlShare` (wrapper over libcurl's [`curl_share_setopt`](https://curl.se/libcurl/c/curl_share_setopt.html)) and a `curl_share=` arg on `Session`/`AsyncSession`, to share the DNS and TLS session caches across a session's thread-local handles.

Per the [share docs](https://curl.se/libcurl/c/CURLSHOPT_SHARE.html), libcurl doesn't support sharing the connection cache between concurrent threads, so it's not shared by default: `CurlShare(connect=True)` opts in, for serialized use only. `duphandle()` doesn't inherit `CURLOPT_SHARE`, so it's re-attached (covers streaming/ws). Docs explain why connection pooling stays per-thread.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
