### PR TITLE
ci: build each Linux arch in its own parallel job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -57,8 +57,23 @@ jobs:
     name: Build bdist wheels and test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15-intel, macos-14, windows-2022, windows-11-arm]
+        include:
+        - os: ubuntu-24.04
+          cibw_archs_linux: "x86_64 i686"
+        - os: ubuntu-24.04-arm
+          cibw_archs_linux: "aarch64"
+        - os: ubuntu-24.04
+          cibw_archs_linux: "riscv64"
+          qemu: true
+        - os: ubuntu-24.04
+          cibw_archs_linux: "armv7l"
+          qemu: true
+        - os: macos-15-intel
+        - os: macos-14
+        - os: windows-2022
+        - os: windows-11-arm
     steps:
     - uses: actions/checkout@v4
 
@@ -66,7 +81,7 @@ jobs:
       with:
         python-version: "3.11"
 
-    - if: runner.os == 'Linux'
+    - if: matrix.qemu
       uses: docker/setup-qemu-action@v3
       with:
         platforms: all
@@ -78,13 +93,15 @@ jobs:
 
     - name: Build and test wheels
       uses: pypa/cibuildwheel@v3.3.1
+      env:
+        CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
 
     # - name: Setup tmate session
     #   uses: mxschmitt/action-tmate@v3
 
     - uses: actions/upload-artifact@v4  # https://github.com/actions/upload-artifact/issues/478
       with:
-        name: curl_cffi-${{ github.sha }}-${{ matrix.os }}.zip
+        name: curl_cffi-${{ github.sha }}-${{ matrix.os }}-${{ strategy.job-index }}.zip
         path: ./wheelhouse/*.whl
 
   bdist_android:


### PR DESCRIPTION
The Linux `bdist` job builds every arch serially in one runner. `aarch64` is compiled *and* runs the full pytest suite under QEMU emulation, which is by far the slowest part.

Split it one-arch-per-job so they run in parallel: `x86_64`+`i686` and `aarch64` build natively (the latter on `ubuntu-24.04-arm`, no QEMU), while `riscv64` and `armv7l` keep their own emulated jobs. CI now waits only for the slowest arch instead of all of them in sequence.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
