### PR TITLE
feat: add status_forcelist to RetryStrategy

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -17,7 +17,7 @@ from collections.abc import (
 )
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from io import BytesIO
 from typing import (
@@ -193,10 +193,24 @@ RetryBackoff = Literal["linear", "exponential"]
 
 @dataclass
 class RetryStrategy:
+    """Configuration for retrying failed requests.
+
+    Attributes:
+        count: maximum number of retries (the first attempt is not counted).
+        delay: base delay in seconds between attempts.
+        jitter: maximum extra random delay in seconds added to each retry.
+        backoff: how ``delay`` grows across attempts, ``"linear"`` or
+            ``"exponential"``.
+        status_forcelist: HTTP status codes that should trigger a retry even when
+            the request itself succeeded (e.g. ``(429, 500, 502, 503, 504)``).
+            Empty by default, meaning only transport errors are retried.
+    """
+
     count: int
     delay: float = 0.0
     jitter: float = 0.0
     backoff: RetryBackoff = "linear"
+    status_forcelist: tuple[int, ...] = ()
 
 
 def _normalize_retry(retry: Optional[Union[int, RetryStrategy]]) -> RetryStrategy:
@@ -216,6 +230,19 @@ def _normalize_retry(retry: Optional[Union[int, RetryStrategy]]) -> RetryStrateg
         raise ValueError("retry.jitter must be >= 0")
     if strategy.backoff not in ("linear", "exponential"):
         raise ValueError("retry.backoff must be 'linear' or 'exponential'")
+    forcelist = strategy.status_forcelist
+    if isinstance(forcelist, list):
+        forcelist = tuple(forcelist)
+    elif not isinstance(forcelist, tuple):
+        raise ValueError("retry.status_forcelist must be a list or tuple of ints")
+    for status in forcelist:
+        if not isinstance(status, int) or not (100 <= status <= 599):
+            raise ValueError(
+                "retry.status_forcelist entries must be ints in the range 100..599"
+            )
+    # never mutate the caller's RetryStrategy; only copy if coercion happened
+    if forcelist is not strategy.status_forcelist:
+        strategy = replace(strategy, status_forcelist=forcelist)
     return strategy
 
 
@@ -471,6 +498,23 @@ class BaseSession(Generic[R]):
             delay += random.uniform(0.0, strategy.jitter)
         return delay
 
+    def _status_retry_delay(self, resp: R, attempt: int) -> float:
+        """Delay before retrying a response with a retryable status code.
+
+        Honours the ``Retry-After`` response header when present and parseable
+        (delta-seconds form, e.g. ``Retry-After: 5``), otherwise falls back to
+        the configured backoff via :meth:`_retry_delay`.
+        """
+        retry_after = resp.headers.get("Retry-After")
+        if retry_after:
+            try:
+                # Only delta-seconds form; HTTP-date falls back to backoff.
+                # Clamp >= 0 so a negative value can't make sleep raise.
+                return max(0.0, float(retry_after.strip()))
+            except (TypeError, ValueError):
+                pass
+        return self._retry_delay(attempt)
+
     @property
     def cookies(self) -> Cookies:
         return self._cookies
@@ -522,6 +566,8 @@ class Session(BaseSession[R]):
                 internal/private IP addresses (SSRF protection).
             max_redirects: max redirect counts, default 30, use -1 for unlimited.
             retry: number of retries or ``RetryStrategy`` for failed requests.
+                Pass a ``RetryStrategy`` with ``status_forcelist`` to also retry on
+                specific HTTP status codes (e.g. 429, 503).
             impersonate: which browser version or fingerprint to impersonate
                 in the session.
             ja3: ja3 string to impersonate in the session.
@@ -900,7 +946,7 @@ class Session(BaseSession[R]):
             if attempt > 0:
                 _rewind_body(body, body_position)
             try:
-                return self._request_once(
+                resp = self._request_once(
                     method=method,
                     url=url,
                     params=params,
@@ -944,6 +990,20 @@ class Session(BaseSession[R]):
                 delay = self._retry_delay(attempt + 1)
                 if delay:
                     time.sleep(delay)
+                continue
+
+            if (
+                strategy.status_forcelist
+                and resp.status_code in strategy.status_forcelist
+                and attempt < strategy.count
+            ):
+                delay = self._status_retry_delay(resp, attempt + 1)
+                resp.close()  # release the handle/stream before retrying
+                if delay:
+                    time.sleep(delay)
+                continue
+
+            return resp
 
     def head(self, url: str, **kwargs: Unpack[RequestParams]) -> R:
         return self.request(method="HEAD", url=url, **kwargs)
@@ -1013,6 +1073,8 @@ class AsyncSession(BaseSession[R]):
                 internal/private IP addresses (SSRF protection).
             max_redirects: max redirect counts, default 30, use -1 for unlimited.
             retry: number of retries or ``RetryStrategy`` for failed requests.
+                Pass a ``RetryStrategy`` with ``status_forcelist`` to also retry on
+                specific HTTP status codes (e.g. 429, 503).
             impersonate: which browser version or fingerprint to impersonate
                 in the session.
             ja3: ja3 string to impersonate in the session.
@@ -1585,7 +1647,7 @@ class AsyncSession(BaseSession[R]):
             if attempt:
                 _rewind_body(body, body_position)
             try:
-                return await self._request_once(
+                resp = await self._request_once(
                     method=method,
                     url=url,
                     params=params,
@@ -1629,6 +1691,23 @@ class AsyncSession(BaseSession[R]):
                 delay = self._retry_delay(attempt + 1)
                 if delay:
                     await asyncio.sleep(delay)
+                continue
+
+            if (
+                strategy.status_forcelist
+                and resp.status_code in strategy.status_forcelist
+                and attempt < strategy.count
+            ):
+                delay = self._status_retry_delay(resp, attempt + 1)
+                # release the handle/stream before retrying
+                if resp.quit_now is not None:
+                    resp.quit_now.set()
+                await resp.aclose()
+                if delay:
+                    await asyncio.sleep(delay)
+                continue
+
+            return resp
 
     async def head(self, url: str, **kwargs: Unpack[RequestParams]) -> R:
         return await self.request(method="HEAD", url=url, **kwargs)

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import http.cookies
+import math
 import os
 import queue
 import random
@@ -508,11 +509,14 @@ class BaseSession(Generic[R]):
         retry_after = resp.headers.get("Retry-After")
         if retry_after:
             try:
-                # Only delta-seconds form; HTTP-date falls back to backoff.
+                # Only finite delta-seconds; HTTP-date falls back to backoff.
                 # Clamp >= 0 so a negative value can't make sleep raise.
-                return max(0.0, float(retry_after.strip()))
+                delay = float(retry_after.strip())
             except (TypeError, ValueError):
                 pass
+            else:
+                if math.isfinite(delay):
+                    return max(0.0, delay)
         return self._retry_delay(attempt)
 
     @property

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -118,6 +118,8 @@ async def app(scope, receive, send):
         await set_special_cookies(scope, receive, send)
     elif scope["path"].startswith("/retry_once"):
         await retry_once(scope, receive, send)
+    elif scope["path"].startswith("/retry_status"):
+        await retry_status(scope, receive, send)
     elif scope["path"].startswith("/retry_body"):
         await retry_body(scope, receive, send)
     elif scope["path"].startswith("/redirect_307"):
@@ -504,6 +506,35 @@ async def retry_once(scope, receive, send):
     await send({"type": "http.response.body", "body": body})
 
 
+_retry_status_counts: dict[str, int] = defaultdict(int)
+
+
+async def retry_status(scope, receive, send):
+    params = parse_qs(scope["query_string"].decode(), keep_blank_values=True)
+    key = params.get("key", ["default"])[0]
+    fail_status = int(params.get("status", ["503"])[0])
+    fail_times = int(params.get("fail_times", ["999"])[0])
+    retry_after = params.get("retry_after", [None])[0]
+
+    _retry_status_counts[key] += 1
+    count = _retry_status_counts[key]
+
+    headers = [
+        [b"content-type", b"text/plain"],
+        [b"x-request-count", str(count).encode()],
+    ]
+    if retry_after is not None:
+        headers.append([b"retry-after", retry_after.encode()])
+
+    if count <= fail_times:
+        status, body = fail_status, b"fail"
+    else:
+        status, body = 200, b"ok"
+
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": body})
+
+
 _retry_body_counts: dict[str, int] = defaultdict(int)
 
 
@@ -710,6 +741,18 @@ def server():
     config = Config(app=app, lifespan="off", loop="asyncio", port=8008)
     server = TestServer(config=config)
     yield from serve_in_thread(server)
+
+
+@pytest.fixture
+def retry_status_url(server):
+    """Build a /retry_status URL with a unique key per call."""
+
+    def _make(**params):
+        params.setdefault("key", uuid4().hex)
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return str(server.url.copy_with(path="/retry_status", query=query.encode()))
+
+    return _make
 
 
 def serve_in_thread(server: Server):

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -9,7 +9,7 @@ import pytest
 
 from curl_cffi import AsyncCurl, CurlOpt, Headers
 from curl_cffi.const import CurlECode
-from curl_cffi.requests import AsyncSession, RequestsError
+from curl_cffi.requests import AsyncSession, RequestsError, RetryStrategy
 from curl_cffi.requests.errors import SessionClosed
 from curl_cffi.requests.exceptions import (
     CertificateVerifyError,
@@ -686,6 +686,24 @@ async def test_async_session_auto_raise_for_status_disabled(server):
         r = await s.get(str(server.url.copy_with(path="/status/404")))
         assert r.status_code == 404
         # Should not raise an exception
+
+
+async def test_status_forcelist_default_no_retry(retry_status_url):
+    url = retry_status_url(status=503)
+    async with AsyncSession(retry=2) as s:
+        r = await s.get(url)
+    assert r.status_code == 503
+    assert r.headers["x-request-count"] == "1"
+
+
+async def test_status_forcelist_stops_on_success(retry_status_url):
+    url = retry_status_url(status=503, fail_times=1)
+    strategy = RetryStrategy(count=3, status_forcelist=(503,))
+    async with AsyncSession(retry=strategy) as s:
+        r = await s.get(url)
+    assert r.status_code == 200
+    assert r.content == b"ok"
+    assert r.headers["x-request-count"] == "2"
 
 
 async def test_shared_async_curl_not_closed_by_session(server):

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -706,6 +706,20 @@ async def test_status_forcelist_stops_on_success(retry_status_url):
     assert r.headers["x-request-count"] == "2"
 
 
+async def test_status_forcelist_stream(retry_status_url):
+    url = retry_status_url(status=503, fail_times=1)
+    strategy = RetryStrategy(count=2, status_forcelist=(503,))
+    async with AsyncSession(retry=strategy, max_clients=1) as s:
+        r = await s.get(url, stream=True)
+        assert r.status_code == 200
+        assert r.headers["x-request-count"] == "2"
+        content = await r.acontent()
+        assert content == b"ok"
+
+        r2 = await s.get(retry_status_url(fail_times=0))
+        assert r2.status_code == 200
+
+
 async def test_shared_async_curl_not_closed_by_session(server):
     pool = AsyncCurl()
 

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -10,6 +10,7 @@ from charset_normalizer import detect
 
 import curl_cffi
 from curl_cffi import Curl, CurlFollow, CurlOpt, requests
+from curl_cffi.requests import RetryStrategy
 from curl_cffi.const import CurlECode, CurlInfo
 from curl_cffi.requests.errors import SessionClosed
 from curl_cffi.requests.exceptions import (
@@ -622,6 +623,52 @@ def test_session_retry(server):
         r = s.get(retry_url)
     assert r.status_code == 200
     assert r.content == b"ok"
+
+
+def test_status_forcelist_default_no_retry(retry_status_url):
+    url = retry_status_url(status=503)
+    with requests.Session(retry=2) as s:
+        r = s.get(url)
+    assert r.status_code == 503
+    assert r.headers["x-request-count"] == "1"
+
+
+def test_status_forcelist_exhausts_then_returns(retry_status_url):
+    url = retry_status_url(status=503)
+    strategy = RetryStrategy(count=2, status_forcelist=(503,))
+    with requests.Session(retry=strategy) as s:
+        r = s.get(url)
+    assert r.status_code == 503
+    assert r.headers["x-request-count"] == "3"
+
+
+def test_status_forcelist_stops_on_success(retry_status_url):
+    url = retry_status_url(status=503, fail_times=1)
+    strategy = RetryStrategy(count=3, status_forcelist=(503,))
+    with requests.Session(retry=strategy) as s:
+        r = s.get(url)
+    assert r.status_code == 200
+    assert r.content == b"ok"
+    assert r.headers["x-request-count"] == "2"
+
+
+def test_status_forcelist_invalid_entries():
+    with pytest.raises(ValueError):
+        requests.Session(retry=RetryStrategy(count=1, status_forcelist=(700,)))
+    with pytest.raises(ValueError):
+        requests.Session(retry=RetryStrategy(count=1, status_forcelist=("503",)))
+
+
+def test_status_forcelist_retry_after_header(retry_status_url):
+    url = retry_status_url(status=503, fail_times=1, retry_after="0.3")
+    strategy = RetryStrategy(count=1, delay=0.0, status_forcelist=(503,))
+    with requests.Session(retry=strategy) as s:
+        start = time.time()
+        r = s.get(url)
+        elapsed = time.time() - start
+    assert r.status_code == 200
+    assert r.headers["x-request-count"] == "2"
+    assert elapsed >= 0.25
 
 
 def test_post_timeout(server):

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -671,6 +671,25 @@ def test_status_forcelist_retry_after_header(retry_status_url):
     assert elapsed >= 0.25
 
 
+def test_status_forcelist_nonfinite_retry_after(retry_status_url):
+    url = retry_status_url(status=503, fail_times=1, retry_after="inf")
+    strategy = RetryStrategy(count=1, status_forcelist=(503,))
+    with requests.Session(retry=strategy) as s:
+        r = s.get(url)
+    assert r.status_code == 200
+    assert r.headers["x-request-count"] == "2"
+
+
+def test_status_forcelist_stream(retry_status_url):
+    url = retry_status_url(status=503, fail_times=1)
+    strategy = RetryStrategy(count=2, status_forcelist=(503,))
+    with requests.Session(retry=strategy) as s, s.stream("GET", url) as r:
+        content = b"".join(r.iter_content())
+    assert r.status_code == 200
+    assert content == b"ok"
+    assert r.headers["x-request-count"] == "2"
+
+
 def test_post_timeout(server):
     with pytest.raises(requests.RequestsError):
         requests.post(str(server.url.copy_with(path="/slow_response")), timeout=0.1)


### PR DESCRIPTION
Retry on retryable HTTP status codes (429, 5xx) in addition to transport errors. Opt-in via `RetryStrategy(status_forcelist=...)`, empty by default so existing behavior is unchanged. Honours `Retry-After` (seconds form) when present, otherwise the configured backoff. Works for both `Session` and `AsyncSession`; the response is released before each retry so no handle/stream leaks.

Closes #781

- [x] I have manually reviewed the changes and fully understand the code.
