### PR TITLE
fix(tests): silence websockets deprecation warnings

### DIFF
--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -646,7 +646,7 @@ class TestServer(Server):
 
 @pytest.fixture(scope="session")
 def server():
-    config = Config(app=app, lifespan="off", loop="asyncio", port=8008)
+    config = Config(app=app, lifespan="off", loop="asyncio", port=8008, ws="none")
     server = TestServer(config=config)
     yield from serve_in_thread(server)
 
@@ -672,6 +672,7 @@ def https_server(cert_pem_file, cert_private_key_file):
         ssl_keyfile=cert_private_key_file,
         port=8001,
         loop="asyncio",
+        ws="none",
     )
     server = TestServer(config=config)
     yield from serve_in_thread(server)
@@ -879,7 +880,9 @@ file_app = Litestar(
 
 @pytest.fixture(scope="session")
 def file_server():
-    config = uvicorn.Config(file_app, host="127.0.0.1", port=2952, log_level="info")
+    config = uvicorn.Config(
+        file_app, host="127.0.0.1", port=2952, log_level="info", ws="none"
+    )
     server = FileServer(config=config)
     with server.run_in_thread():
         yield server

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -38,6 +38,7 @@ def test_create_session_out_of_async(server):
     async def get():
         r = await s.get(str(server.url))
         assert r.status_code == 200
+        await s.close()
 
     asyncio.run(get())
 


### PR DESCRIPTION
Silence the websockets `DeprecationWarning`s in the test suite. uvicorn's default `ws="auto"` loads the legacy `websockets_impl` (deprecated under websockets 15) at server startup, even though the test servers are HTTP-only (the ws tests use `websockets.serve` directly), so set `ws="none"` on those `Config`s.

Also close the session in `test_create_session_out_of_async` so it no longer leaks an unclosed event loop (`ResourceWarning`).

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
