### PR TITLE
feat: add Response.is_redirect

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -43,6 +43,7 @@ JSON_NATIVE_ENCODINGS = {
     "utf-32le",
 }
 STREAM_END = object()
+REDIRECT_STATI = (301, 302, 303, 307, 308)
 
 
 def clear_queue(q: queue.Queue):
@@ -209,6 +210,11 @@ class Response:
         """Raise an error if status code is not in [200, 400)"""
         if not self.ok:
             raise HTTPError(f"HTTP Error {self.status_code}: {self.reason}", 0, self)
+
+    @property
+    def is_redirect(self) -> bool:
+        """Whether this response is a well-formed redirect."""
+        return "location" in self.headers and self.status_code in REDIRECT_STATI
 
     def iter_lines(self, chunk_size=None, decode_unicode=False, delimiter=None):
         """

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -344,18 +344,9 @@ def test_response_is_redirect():
         assert r.is_redirect
 
     r = Response()
-    r.status_code = 301
-    assert not r.is_redirect
-
-    r = Response()
     r.status_code = 304
     r.headers["Location"] = "/"
     assert not r.is_redirect
-
-    r = Response()
-    r.status_code = 302
-    r.headers["LOCATION"] = "/"
-    assert r.is_redirect
 
 
 def test_charset_default_encoding(server):

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -336,6 +336,28 @@ def test_json_bytes_bom_parse():
     assert r.json()["foo"] == "bar"
 
 
+def test_response_is_redirect():
+    for status_code in (301, 302, 303, 307, 308):
+        r = Response()
+        r.status_code = status_code
+        r.headers["Location"] = "/"
+        assert r.is_redirect
+
+    r = Response()
+    r.status_code = 301
+    assert not r.is_redirect
+
+    r = Response()
+    r.status_code = 304
+    r.headers["Location"] = "/"
+    assert not r.is_redirect
+
+    r = Response()
+    r.status_code = 302
+    r.headers["LOCATION"] = "/"
+    assert r.is_redirect
+
+
 def test_charset_default_encoding(server):
     r = requests.get(
         str(server.url.copy_with(path="/windows1251")), default_encoding="windows-1251"


### PR DESCRIPTION
This PR adds better compatibility with `requests` library.

`is_redirect` will be determined based on `Response.status_code` and whether it has `location` in `Response.headers`

Ref: https://github.com/psf/requests/blob/main/src/requests/models.py#L877 

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
