### PR TITLE
fix(docs/quick_start): requests => curl_cffi typo

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -95,7 +95,7 @@ Messing with the URLs:
     import curl_cffi
 
     >>> params = {"foo": "bar"}
-    >>> r = requests.get("http://httpbin.org/get", params=params)
+    >>> r = curl_cffi.get("http://httpbin.org/get", params=params)
     >>> r.url
     'http://httpbin.org/get?foo=bar'
 


### PR DESCRIPTION
## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
