### PR TITLE
fix(requests): fall back to stdlib json in Response.json() when kwargs are passed (#639)

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -3,6 +3,7 @@ import queue
 import re
 import warnings
 from concurrent.futures import Future
+from json import loads as _stdlib_loads
 from typing import Any, Optional, Union
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
@@ -13,11 +14,12 @@ from .cookies import Cookies
 from .exceptions import HTTPError, RequestException
 from .headers import Headers
 
-# Use orjson if present
+# Use orjson if present. orjson.loads() is faster but accepts no keyword
+# arguments, so Response.json() falls back to stdlib json when kwargs are given.
 try:
     from orjson import loads
 except ImportError:
-    from json import loads
+    loads = _stdlib_loads
 
 with suppress(ImportError):
     from markdownify import markdownify as md
@@ -274,12 +276,15 @@ class Response:
 
     def json(self, **kw):
         """return a parsed json object of the content."""
+        # orjson.loads() takes no keyword arguments, so fall back to the stdlib
+        # json parser whenever the caller passes any (e.g. parse_float). See #639.
+        _loads = _stdlib_loads if kw else loads
         charset_encoding = self.charset_encoding
         if charset_encoding is not None:
             encoding = charset_encoding.lower().replace("_", "-")
             if encoding not in JSON_NATIVE_ENCODINGS:
-                return loads(self.text, **kw)
-        return loads(self.content, **kw)
+                return _loads(self.text, **kw)
+        return _loads(self.content, **kw)
 
     def close(self):
         """Close the streaming connection, only valid in stream mode."""

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -336,6 +336,21 @@ def test_json_bytes_bom_parse():
     assert r.json()["foo"] == "bar"
 
 
+def test_json_kwargs_with_orjson():
+    # Regression test for gh #639: Response.json() forwards kwargs to loads(),
+    # but orjson.loads() takes no keyword arguments. When orjson is installed
+    # this used to raise TypeError, making behavior depend on whether orjson
+    # happens to be present. Passing kwargs must fall back to stdlib json.
+    from decimal import Decimal
+
+    r = Response()
+    r.headers["Content-Type"] = "application/json"
+    r.content = b'{"price": 1.1}'
+    parsed = r.json(parse_float=Decimal)
+    assert parsed["price"] == Decimal("1.1")
+    assert isinstance(parsed["price"], Decimal)
+
+
 def test_response_is_redirect():
     for status_code in (301, 302, 303, 307, 308):
         r = Response()


### PR DESCRIPTION
Fixes #639

## Root cause
`Response.json(**kw)` forwards its keyword arguments straight to `loads()`:

```python
return loads(self.content, **kw)
```

In `curl_cffi/requests/models.py`, `loads` is bound to `orjson.loads` when orjson is installed and to `json.loads` otherwise. `orjson.loads()` accepts no keyword arguments, whereas the stdlib `json.loads()` does. A call such as `response.json(parse_float=Decimal)` therefore raises `TypeError` only when orjson is installed.

## Fix
Keep the faster `orjson.loads` for the common no-kwargs case, but fall back to the stdlib `json.loads` whenever the caller passes keyword arguments. The no-kwargs fast path is unchanged.

## Tests
Added `test_json_kwargs_with_orjson`, which verifies that `r.json(parse_float=Decimal)` returns a `Decimal` when orjson is installed.

- The regression test fails on unmodified code with `TypeError`.
- The regression test and surrounding JSON/redirect tests pass with this fix.
- `ruff check` and `ruff format --check` are clean on the changed files.

## Review checklist

- [x] I have manually reviewed the changes and fully understand the code.

Disclosure: prepared with AI assistance; manually reviewed and verified locally.
