### PR TITLE
Use real pause in streaming mode

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -71,6 +71,7 @@ CURL_WRITEFUNC_PAUSE = 0x10000001
 CURL_WRITEFUNC_ERROR = 0xFFFFFFFF
 CURL_READFUNC_ABORT = 0x10000000
 CURL_READFUNC_PAUSE = 0x10000001
+CURLPAUSE_CONT = 0
 
 
 @ffi.def_extern()
@@ -521,6 +522,14 @@ class Curl:
         if self._curl is None:
             return 0  # silently ignore if curl handle is None
         return lib.curl_easy_upkeep(self._curl)
+
+    def pause(self, action: int) -> int:
+        """Pause or unpause a transfer, wrapping ``curl_easy_pause``."""
+        if self._curl is None:
+            raise CurlError("Cannot pause a closed handle.")
+        ret = lib.curl_easy_pause(self._curl, action)
+        self._check_error(ret, "pause")
+        return ret
 
     def clean_handles_and_buffers(
         self, clear_headers: bool = True, clear_resolve: bool = True

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -132,6 +132,7 @@ def request(
         cert: a tuple of (cert, key) filenames for client cert.
         stream: streaming the response, default False.
         max_recv_speed: maximum receive speed, bytes per second.
+        stream_queue_size: maximum number of response chunks buffered while streaming.
         multipart: upload files using the multipart format, see examples for details.
         discard_cookies: discard cookies from server. Default to False.
 

--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -1,3 +1,4 @@
+from asyncio import CancelledError
 from contextlib import suppress
 import queue
 import re
@@ -135,6 +136,7 @@ class Response:
         self.stream_task: Optional[Future] = None
         self.astream_task: Optional[Awaitable] = None
         self.quit_now = None
+        self.stream_control = None
         self._stream_closed = False
         self.download_size: int = 0
         self.upload_size: int = 0
@@ -291,7 +293,9 @@ class Response:
         if self.queue is None and self.stream_task is None and self.quit_now is None:
             return
         self._stream_closed = True
-        if self.quit_now:
+        if self.stream_control:
+            self.stream_control.abort()
+        elif self.quit_now:
             self.quit_now.set()
         if self.stream_task:
             self.stream_task.result()
@@ -342,6 +346,8 @@ class Response:
 
         while True:
             chunk = await self.queue.get()
+            if self.stream_control:
+                self.stream_control.resume()
 
             # re-raise the exception if something wrong happened.
             if isinstance(chunk, RequestException):
@@ -370,9 +376,22 @@ class Response:
 
     async def aclose(self):
         """Close the streaming connection, only valid in stream mode."""
-
+        if self._stream_closed:
+            return
+        if self.queue is None and self.astream_task is None and self.quit_now is None:
+            return
+        self._stream_closed = True
+        if self.stream_control:
+            self.stream_control.abort()
+        elif self.quit_now:
+            self.quit_now.set()
         if self.astream_task:
-            await self.astream_task
+            cancel = getattr(self.astream_task, "cancel", None)
+            done = getattr(self.astream_task, "done", None)
+            if cancel and (done is None or not done()):
+                cancel()
+            with suppress(CancelledError):
+                await self.astream_task
 
     # It prints the status code of the response instead of the object's memory location.
     def __repr__(self) -> str:

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -44,7 +44,13 @@ from .exceptions import RequestException, SessionClosed, code2error
 from .headers import Headers, HeaderTypes
 from .impersonate import BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
 from .models import STREAM_END, Response
-from .utils import NOT_SET, HttpVersionLiteral, NotSetType, set_curl_options
+from .utils import (
+    DEFAULT_STREAM_QUEUE_SIZE,
+    NOT_SET,
+    HttpVersionLiteral,
+    NotSetType,
+    set_curl_options,
+)
 from .websockets import (
     AsyncWebSocket,
     AsyncWebSocketContext,
@@ -136,6 +142,7 @@ if TYPE_CHECKING:
         doh_url: Optional[str]
         cert: Optional[Union[str, tuple[str, str]]]
         max_recv_speed: int
+        stream_queue_size: int
         multipart: Optional[CurlMime]
         discard_cookies: bool
 
@@ -654,6 +661,7 @@ class Session(BaseSession[R]):
         cert: Optional[Union[str, tuple[str, str]]] = None,
         stream: Optional[bool] = None,
         max_recv_speed: int = 0,
+        stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
         multipart: Optional[CurlMime] = None,
         discard_cookies: bool = False,
     ) -> R:
@@ -664,7 +672,15 @@ class Session(BaseSession[R]):
         else:
             c = self.curl
 
-        req, buffer, header_buffer, q, header_recved, quit_now = set_curl_options(
+        (
+            req,
+            buffer,
+            header_buffer,
+            q,
+            header_recved,
+            quit_now,
+            stream_control,
+        ) = set_curl_options(
             c,
             method=method,
             url=url,
@@ -704,6 +720,7 @@ class Session(BaseSession[R]):
             doh_url=doh_url or self.doh_url,
             stream=stream,
             max_recv_speed=max_recv_speed,
+            stream_queue_size=stream_queue_size,
             multipart=multipart,
             cert=cert or self.cert,
             curl_options=self.curl_options,
@@ -730,16 +747,21 @@ class Session(BaseSession[R]):
                 try:
                     c.perform()
                 except CurlError as e:
-                    rsp = self._parse_response(
-                        c, buffer, header_buffer, default_encoding, discard_cookies
-                    )
-                    rsp.request = req
-                    error = code2error(e.code, str(e))
-                    q.put_nowait(error(str(e), e.code, rsp))  # type: ignore
+                    if not stream_control.quit_now.is_set():
+                        rsp = self._parse_response(
+                            c,
+                            buffer,
+                            header_buffer,
+                            default_encoding,
+                            discard_cookies,
+                        )
+                        rsp.request = req
+                        error = code2error(e.code, str(e))
+                        stream_control.put(error(str(e), e.code, rsp))
                 finally:
                     if not cast(threading.Event, header_recved).is_set():
                         cast(threading.Event, header_recved).set()
-                    q.put(STREAM_END)  # type: ignore
+                    stream_control.put(STREAM_END)
 
             stream_task = self.executor.submit(perform)
 
@@ -752,8 +774,7 @@ class Session(BaseSession[R]):
             # Raise the exception if something wrong happens when receiving the header.
             first_element = _peek_queue(q)  # type: ignore
             if isinstance(first_element, RequestException):
-                if quit_now:
-                    quit_now.set()
+                stream_control.abort()
                 stream_task.result()
                 c.close()
                 raise first_element
@@ -761,9 +782,14 @@ class Session(BaseSession[R]):
             rsp.request = req
             rsp.stream_task = stream_task
             rsp.quit_now = quit_now
+            rsp.stream_control = stream_control
             rsp.queue = q
             if self.raise_for_status:
-                rsp.raise_for_status()
+                try:
+                    rsp.raise_for_status()
+                except RequestException:
+                    rsp.close()
+                    raise
             return rsp
         else:
             try:
@@ -836,6 +862,7 @@ class Session(BaseSession[R]):
         cert: Optional[Union[str, tuple[str, str]]] = None,
         stream: Optional[bool] = None,
         max_recv_speed: int = 0,
+        stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
         multipart: Optional[CurlMime] = None,
         discard_cookies: bool = False,
     ):
@@ -880,6 +907,7 @@ class Session(BaseSession[R]):
                     cert=cert,
                     stream=stream,
                     max_recv_speed=max_recv_speed,
+                    stream_queue_size=stream_queue_size,
                     multipart=multipart,
                     discard_cookies=discard_cookies,
                 )
@@ -1336,11 +1364,20 @@ class AsyncSession(BaseSession[R]):
         cert: Optional[Union[str, tuple[str, str]]] = None,
         stream: Optional[bool] = None,
         max_recv_speed: int = 0,
+        stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
         multipart: Optional[CurlMime] = None,
         discard_cookies: bool = False,
     ) -> R:
         curl = await self.pop_curl()
-        req, buffer, header_buffer, q, header_recved, quit_now = set_curl_options(
+        (
+            req,
+            buffer,
+            header_buffer,
+            q,
+            header_recved,
+            quit_now,
+            stream_control,
+        ) = set_curl_options(
             curl=curl,
             method=method,
             url=url,
@@ -1380,6 +1417,7 @@ class AsyncSession(BaseSession[R]):
             doh_url=doh_url or self.doh_url,
             stream=stream,
             max_recv_speed=max_recv_speed,
+            stream_queue_size=stream_queue_size,
             multipart=multipart,
             cert=cert or self.cert,
             curl_options=self.curl_options,
@@ -1394,16 +1432,22 @@ class AsyncSession(BaseSession[R]):
                 try:
                     await task
                 except CurlError as e:
-                    rsp = self._parse_response(
-                        curl, buffer, header_buffer, default_encoding, discard_cookies
-                    )
-                    rsp.request = req
-                    error = code2error(e.code, str(e))
-                    q.put_nowait(error(str(e), e.code, rsp))  # type: ignore
+                    if not stream_control.quit_now.is_set():
+                        rsp = self._parse_response(
+                            curl,
+                            buffer,
+                            header_buffer,
+                            default_encoding,
+                            discard_cookies,
+                        )
+                        rsp.request = req
+                        error = code2error(e.code, str(e))
+                        await q.put(error(str(e), e.code, rsp))
                 finally:
                     if not cast(asyncio.Event, header_recved).is_set():
                         cast(asyncio.Event, header_recved).set()
-                    await q.put(STREAM_END)  # type: ignore
+                    if not stream_control.quit_now.is_set():
+                        await q.put(STREAM_END)
 
             def cleanup(fut):
                 nonlocal curl_released
@@ -1426,17 +1470,26 @@ class AsyncSession(BaseSession[R]):
 
             first_element = _peek_aio_queue(q)  # type: ignore
             if isinstance(first_element, RequestException):
+                stream_control.abort()
                 if not curl_released:
                     self.release_curl(curl)
                 curl_released = True
+                stream_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await stream_task
                 raise first_element
 
             rsp.request = req
             rsp.astream_task = stream_task
             rsp.quit_now = quit_now
+            rsp.stream_control = stream_control
             rsp.queue = q
             if self.raise_for_status:
-                rsp.raise_for_status()
+                try:
+                    rsp.raise_for_status()
+                except RequestException:
+                    await rsp.aclose()
+                    raise
             return rsp
         else:
             try:
@@ -1499,6 +1552,7 @@ class AsyncSession(BaseSession[R]):
         cert: Optional[Union[str, tuple[str, str]]] = None,
         stream: Optional[bool] = None,
         max_recv_speed: int = 0,
+        stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
         multipart: Optional[CurlMime] = None,
         discard_cookies: bool = False,
     ) -> R:
@@ -1543,6 +1597,7 @@ class AsyncSession(BaseSession[R]):
                     cert=cert,
                     stream=stream,
                     max_recv_speed=max_recv_speed,
+                    stream_queue_size=stream_queue_size,
                     multipart=multipart,
                     discard_cookies=discard_cookies,
                 )

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -10,13 +10,20 @@ import queue
 import warnings
 from collections import Counter
 from collections.abc import Callable
+from contextlib import suppress
 from io import BytesIO
 from json import dumps
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Union, cast, final
 from urllib.parse import ParseResult, parse_qsl, quote, urlencode, urljoin, urlparse
 
 from ..const import CurlFollow, CurlHttpVersion, CurlOpt, CurlSslVersion
-from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
+from ..curl import (
+    CURL_WRITEFUNC_ERROR,
+    CURL_WRITEFUNC_PAUSE,
+    CURLPAUSE_CONT,
+    CurlError,
+    CurlMime,
+)
 from ..utils import CurlCffiWarning, HttpVersionLiteral
 from ..fingerprints import Fingerprint, FingerprintManager, NATIVE_IMPERSONATE_TARGETS
 from .cookies import Cookies
@@ -64,6 +71,59 @@ class NotSetType:
 
 
 NOT_SET: Final[NotSetType] = NotSetType()
+DEFAULT_STREAM_QUEUE_SIZE = 128
+
+
+class StreamControl:
+    """Coordinate backpressure and cancellation for a streaming transfer."""
+
+    def __init__(self, curl, q, quit_now, *, asynchronous: bool) -> None:
+        self.curl = curl
+        self.q = q
+        self.quit_now = quit_now
+        self.asynchronous = asynchronous
+        self.paused = False
+
+    def write(self, chunk: bytes) -> int:
+        if self.quit_now.is_set():
+            return CURL_WRITEFUNC_ERROR
+
+        if self.asynchronous:
+            if self.q.full():
+                self.paused = True
+                return CURL_WRITEFUNC_PAUSE
+            self.q.put_nowait(chunk)
+            return len(chunk)
+
+        while not self.quit_now.is_set():
+            try:
+                self.q.put(chunk, timeout=0.1)
+                return len(chunk)
+            except queue.Full:
+                pass
+        return CURL_WRITEFUNC_ERROR
+
+    def put(self, item: object) -> bool:
+        """Put a terminal item into a synchronous queue unless it was aborted."""
+        while not self.quit_now.is_set():
+            try:
+                self.q.put(item, timeout=0.1)
+                return True
+            except queue.Full:
+                pass
+        return False
+
+    def resume(self) -> None:
+        if not self.paused:
+            return
+        self.paused = False
+        self.curl.pause(CURLPAUSE_CONT)
+
+    def abort(self) -> None:
+        self.quit_now.set()
+        # A paused write callback returns CURL_WRITEFUNC_ERROR while aborting.
+        with suppress(CurlError):
+            self.resume()
 
 
 # ruff: noqa: SIM116
@@ -643,6 +703,7 @@ def set_curl_options(
     cert: Optional[Union[str, tuple[str, str]]] = None,
     stream: Optional[bool] = None,
     max_recv_speed: int = 0,
+    stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
     multipart: Optional[CurlMime] = None,
     queue_class: Any = None,
     event_class: Any = None,
@@ -978,18 +1039,24 @@ def set_curl_options(
     q = None
     header_recved = None
     quit_now = None
+    stream_control = None
     if stream:
-        q = queue_class()
+        if stream_queue_size < 1:
+            raise ValueError("stream_queue_size must be greater than 0")
+        q = queue_class(maxsize=stream_queue_size)
         header_recved = event_class()
         quit_now = event_class()
+        stream_control = StreamControl(
+            c,
+            q,
+            quit_now,
+            asynchronous=queue_class is asyncio.Queue,
+        )
 
         def qput(chunk):
             if not header_recved.is_set():
                 header_recved.set()
-            if quit_now.is_set():
-                return CURL_WRITEFUNC_ERROR
-            q.put_nowait(chunk)
-            return len(chunk)
+            return stream_control.write(chunk)
 
         c.setopt(CurlOpt.WRITEFUNCTION, qput)
     elif content_callback is not None:
@@ -1024,4 +1091,4 @@ def set_curl_options(
         for option, setting in curl_options.items():
             c.setopt(option, setting)
 
-    return req, buffer, header_buffer, q, header_recved, quit_now
+    return req, buffer, header_buffer, q, header_recved, quit_now, stream_control

--- a/ffi/cdef.c
+++ b/ffi/cdef.c
@@ -3,6 +3,7 @@ void *curl_easy_init();
 int _curl_easy_setopt(void *curl, int option, void *param);
 int curl_easy_getinfo(void *curl, int option, void *ret);
 int curl_easy_perform(void *curl);
+int curl_easy_pause(void *curl, int action);
 void curl_easy_cleanup(void *curl);
 void curl_easy_reset(void *curl);
 int curl_easy_impersonate(void *curl, char *target, int default_headers);

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -446,7 +446,9 @@ async def test_stream_iter_content(server):
 async def test_stream_iter_content_break(server):
     async with AsyncSession() as s:
         url = str(server.url.copy_with(path="/stream"))
-        async with s.stream("GET", url, params={"n": "20"}) as r:
+        async with s.stream(
+            "GET", url, params={"n": "10000"}, stream_queue_size=1
+        ) as r:
             idx = 0
             async for chunk in r.aiter_content():
                 idx += 1

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -452,7 +452,7 @@ async def test_stream_iter_content_break(server):
             idx = 0
             async for chunk in r.aiter_content():
                 idx += 1
-                assert b"path" in chunk
+                assert chunk
                 if idx == 3:
                     break
             assert r.status_code == 200

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -907,7 +907,7 @@ def test_stream_iter_content(server):
 def test_stream_iter_content_break(server):
     with requests.Session() as s:
         url = str(server.url.copy_with(path="/stream"))
-        with s.stream("GET", url, params={"n": "20"}) as r:
+        with s.stream("GET", url, params={"n": "10000"}, stream_queue_size=1) as r:
             for idx, chunk in enumerate(r.iter_content()):
                 assert b"path" in chunk
                 if idx == 3:

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -909,7 +909,7 @@ def test_stream_iter_content_break(server):
         url = str(server.url.copy_with(path="/stream"))
         with s.stream("GET", url, params={"n": "10000"}, stream_queue_size=1) as r:
             for idx, chunk in enumerate(r.iter_content()):
-                assert b"path" in chunk
+                assert chunk
                 if idx == 3:
                     break
             assert r.status_code == 200

--- a/tests/unittest/test_setopt.py
+++ b/tests/unittest/test_setopt.py
@@ -1,8 +1,12 @@
+import asyncio
+import queue
+import threading
 from unittest.mock import Mock
 
 import pytest
 
 from curl_cffi.const import CurlHttpVersion, CurlOpt, CurlSslVersion
+from curl_cffi.curl import CURL_WRITEFUNC_ERROR, CURL_WRITEFUNC_PAUSE, CURLPAUSE_CONT
 from curl_cffi.requests.impersonate import ExtraFingerprints
 from curl_cffi.requests import utils
 
@@ -10,9 +14,92 @@ from curl_cffi.requests import utils
 class FakeCurl:
     def __init__(self):
         self.options = {}
+        self.pause_calls = []
 
     def setopt(self, option, value):
         self.options[option] = value
+
+    def pause(self, action):
+        self.pause_calls.append(action)
+        return 0
+
+
+def _set_stream_options(curl, queue_class, event_class):
+    return utils.set_curl_options(
+        curl,
+        "GET",
+        "https://example.com/",
+        params_list=[None, None],
+        headers_list=[None, None],
+        cookies_list=[None, None],
+        proxies_list=[None, None],
+        verify_list=[True, None],
+        stream=True,
+        stream_queue_size=1,
+        queue_class=queue_class,
+        event_class=event_class,
+    )
+
+
+def test_sync_stream_queue_applies_interruptible_backpressure():
+    curl = FakeCurl()
+    _, _, _, q, _, _, control = _set_stream_options(curl, queue.Queue, threading.Event)
+    write = curl.options[CurlOpt.WRITEFUNCTION]
+
+    assert q.maxsize == 1
+    assert write(b"first") == len(b"first")
+
+    result = []
+    started = threading.Event()
+
+    def write_second_chunk():
+        started.set()
+        result.append(write(b"second"))
+
+    writer = threading.Thread(target=write_second_chunk)
+    writer.start()
+    assert started.wait(timeout=1)
+    writer.join(timeout=0.05)
+    assert writer.is_alive()
+
+    control.abort()
+    writer.join(timeout=1)
+    assert result == [CURL_WRITEFUNC_ERROR]
+
+
+def test_async_stream_queue_pauses_and_resumes_curl():
+    curl = FakeCurl()
+    _, _, _, q, _, _, control = _set_stream_options(curl, asyncio.Queue, asyncio.Event)
+    write = curl.options[CurlOpt.WRITEFUNCTION]
+
+    assert q.maxsize == 1
+    assert write(b"first") == len(b"first")
+    assert write(b"second") == CURL_WRITEFUNC_PAUSE
+    assert q.get_nowait() == b"first"
+
+    control.resume()
+    assert curl.pause_calls == [CURLPAUSE_CONT]
+    assert write(b"second") == len(b"second")
+
+
+def test_stream_queue_size_must_be_positive():
+    curl = FakeCurl()
+
+    with pytest.raises(ValueError, match="stream_queue_size"):
+        utils.set_curl_options(
+            curl,
+            "GET",
+            "https://example.com/",
+            params_list=[None, None],
+            headers_list=[None, None],
+            cookies_list=[None, None],
+            proxies_list=[None, None],
+            verify_list=[True, None],
+            stream=True,
+            stream_queue_size=0,
+            queue_class=queue.Queue,
+            event_class=threading.Event,
+        )
 
 
 def test_set_curl_options_routes_perk_to_perk_options(monkeypatch):


### PR DESCRIPTION
## Checklist

- [x] I have manually reviewed the changes and fully understand the code.

Close #798 

## Engineering summary

- Use blocking q.put for sync client
- Use `curl_easy_pause` for async client