### PR TITLE
fix: clean up cancelled AsyncCurl handles

### DIFF
--- a/curl_cffi/aio.py
+++ b/curl_cffi/aio.py
@@ -208,9 +208,12 @@ class AsyncCurl:
 
         # Close all pending futures
         for curl, future in self._curl2future.items():
-            lib.curl_multi_remove_handle(self._curlm, curl._curl)
+            if curl._curl is not None:
+                lib.curl_multi_remove_handle(self._curlm, curl._curl)
             if not future.done() and not future.cancelled():
                 future.set_result(None)
+        self._curl2future.clear()
+        self._curl2curl.clear()
 
         # Cleanup curl_multi handle
         lib.curl_multi_cleanup(self._curlm)
@@ -296,16 +299,23 @@ class AsyncCurl:
                 )
 
     def _pop_future(self, curl: Curl):
-        errcode = lib.curl_multi_remove_handle(self._curlm, curl._curl)
-        self._check_error(errcode)
-        self._curl2curl.pop(curl._curl, None)
-        return self._curl2future.pop(curl, None)
+        curl_handle = curl._curl
+        try:
+            errcode = lib.curl_multi_remove_handle(self._curlm, curl_handle)
+            self._check_error(errcode)
+        finally:
+            self._curl2curl.pop(curl_handle, None)
+            future = self._curl2future.pop(curl, None)
+        return future
 
     def remove_handle(self, curl: Curl):
         """Cancel a future for given curl handle."""
-        future = self._pop_future(curl)
-        if future and not future.done() and not future.cancelled():
-            future.cancel()
+        future = self._curl2future.get(curl)
+        try:
+            self._pop_future(curl)
+        finally:
+            if future and not future.done() and not future.cancelled():
+                future.cancel()
 
     def set_result(self, curl: Curl):
         """Mark a future as done for given curl handle."""

--- a/tests/unittest/test_async.py
+++ b/tests/unittest/test_async.py
@@ -1,6 +1,6 @@
 import pytest
 
-from curl_cffi import AsyncCurl, Curl, CurlOpt
+from curl_cffi import AsyncCurl, Curl, CurlError, CurlOpt
 
 
 async def test_init(server):
@@ -27,6 +27,43 @@ async def test_add_handle_callback_exception(server):
     c.setopt(CurlOpt.WRITEFUNCTION, write)
     with pytest.raises(ValueError, match="callback failed"):
         await ac.add_handle(c)
+    await ac.close()
+
+
+async def test_close_ignores_already_closed_curl():
+    ac = AsyncCurl()
+    c = Curl()
+    c.setopt(CurlOpt.URL, "http://example.com")
+    future = ac.add_handle(c)
+
+    future.cancel()
+    c.close()
+
+    await ac.close()
+
+    assert not ac._curl2future
+    assert not ac._curl2curl
+
+
+async def test_remove_handle_error_cleans_up_closed_curl(monkeypatch):
+    ac = AsyncCurl()
+    c = Curl()
+    c.setopt(CurlOpt.URL, "http://example.com")
+    future = ac.add_handle(c)
+
+    def raise_remove_error(*args):
+        raise CurlError("remove failed")
+
+    monkeypatch.setattr(ac, "_check_error", raise_remove_error)
+
+    with pytest.raises(CurlError, match="remove failed"):
+        ac.remove_handle(c)
+
+    assert future.cancelled()
+    assert c not in ac._curl2future
+    assert c._curl not in ac._curl2curl
+
+    c.close()
     await ac.close()
 
 


### PR DESCRIPTION
## Summary

- skip already-closed easy handles while shutting down `AsyncCurl`
- always discard handle/future bookkeeping when `curl_multi_remove_handle` reports an error
- cancel the pending future even when removal raises
- add deterministic regressions for both cancellation cleanup paths

## Test plan

- `python -bb -m pytest tests/unittest/test_async.py::test_close_ignores_already_closed_curl tests/unittest/test_async.py::test_remove_handle_error_cleans_up_closed_curl -q`
- `python -bb -m pytest tests/unittest/test_async.py -q`
- `ruff check curl_cffi/aio.py tests/unittest/test_async.py`
- `ruff format --check curl_cffi/aio.py tests/unittest/test_async.py`

## AI disclosure

This contribution was prepared with OpenAI Codex assistance. The issue, repository policies, competing work, implementation, diff, and focused validation were checked before submission.

Closes #802
