### PR TITLE
fix: tolerate closed curl handles in AsyncCurl cleanup

### DIFF
--- a/curl_cffi/aio.py
+++ b/curl_cffi/aio.py
@@ -208,7 +208,8 @@ class AsyncCurl:
 
         # Close all pending futures
         for curl, future in self._curl2future.items():
-            lib.curl_multi_remove_handle(self._curlm, curl._curl)
+            if curl._curl is not None:
+                lib.curl_multi_remove_handle(self._curlm, curl._curl)
             if not future.done() and not future.cancelled():
                 future.set_result(None)
 
@@ -296,10 +297,17 @@ class AsyncCurl:
                 )
 
     def _pop_future(self, curl: Curl):
-        errcode = lib.curl_multi_remove_handle(self._curlm, curl._curl)
-        self._check_error(errcode)
         self._curl2curl.pop(curl._curl, None)
-        return self._curl2future.pop(curl, None)
+        future = self._curl2future.pop(curl, None)
+        try:
+            if curl._curl is not None:
+                errcode = lib.curl_multi_remove_handle(self._curlm, curl._curl)
+                self._check_error(errcode)
+        except CurlError:
+            if future and not future.done() and not future.cancelled():
+                future.cancel()
+            raise
+        return future
 
     def remove_handle(self, curl: Curl):
         """Cancel a future for given curl handle."""

--- a/tests/unittest/test_async.py
+++ b/tests/unittest/test_async.py
@@ -30,6 +30,30 @@ async def test_add_handle_callback_exception(server):
     await ac.close()
 
 
+async def test_close_with_curl_closed_after_cancel(server):
+    ac = AsyncCurl()
+    c = Curl()
+    c.setopt(CurlOpt.URL, str(server.url).encode())
+    c.setopt(CurlOpt.WRITEFUNCTION, lambda x: len(x))
+    fut = ac.add_handle(c)
+    fut.cancel()
+    c.close()
+    await ac.close()
+
+
+async def test_remove_handle_with_closed_curl(server):
+    ac = AsyncCurl()
+    c = Curl()
+    c.setopt(CurlOpt.URL, str(server.url).encode())
+    c.setopt(CurlOpt.WRITEFUNCTION, lambda x: len(x))
+    fut = ac.add_handle(c)
+    c.close()
+    ac.remove_handle(c)
+    assert fut.cancelled()
+    assert c not in ac._curl2future
+    await ac.close()
+
+
 async def test_socket_action(server):
     ac = AsyncCurl()
     running = ac.socket_action(-1, 0)


### PR DESCRIPTION
Fixes #802. Closing a `Curl` handle while `AsyncCurl` still tracks it (e.g. `add_handle` cancelled by a timeout, then `curl.close()`) left its entries in the internal maps with a nulled pointer, so a later `AsyncCurl.close()` raised `TypeError: initializer for ctype 'void *' must be a cdata pointer, not NoneType`.

`close()` and `_pop_future()` now skip the C-level removal for already-closed handles, `_pop_future()` drops the bookkeeping entries even when `curl_multi_remove_handle` fails (the race in the follow-up comment), and the popped future is cancelled before re-raising so no task is left hanging. Both regression tests fail with the `TypeError` on current main.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
