### PR TITLE
fix: don't set Session.cache attribute when caching is disabled

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -283,7 +283,9 @@ class BaseSession(Generic[R]):
         self.interface = interface
         self.doh_url = doh_url
         self.cert = cert
-        self.cache = normalize_cache_backend(cache)
+        cache_backend = normalize_cache_backend(cache)
+        if cache_backend is not None:
+            self.cache = cache_backend
 
         if response_class is not None and issubclass(response_class, Response) is False:
             raise TypeError(
@@ -452,9 +454,10 @@ class BaseSession(Generic[R]):
         stream: Optional[bool],
         content_callback: Optional[Callable[..., object]],
     ) -> bool:
+        cache = getattr(self, "cache", None)
         return bool(
-            self.cache
-            and self.cache.should_cache_request(
+            cache
+            and cache.should_cache_request(
                 request,
                 stream=bool(stream),
                 content_callback=content_callback,

--- a/tests/unittest/test_cache.py
+++ b/tests/unittest/test_cache.py
@@ -152,6 +152,31 @@ def test_async_session_rejects_cache_shorthand():
         AsyncSession(cache=timedelta(seconds=60))
 
 
+def test_session_without_cache_has_no_cache_attribute():
+    with Session() as session:
+        assert not hasattr(session, "cache")
+
+
+def test_session_with_cache_exposes_cache_attribute(tmp_path):
+    cache = FileCacheBackend(expires=timedelta(seconds=60), path=tmp_path)
+
+    with Session(cache=cache) as session:
+        assert session.cache is cache
+
+
+def test_cache_assigned_after_construction(server, tmp_path):
+    cache = FileCacheBackend(expires=timedelta(seconds=60), path=tmp_path)
+    url = str(server.url.copy_with(path="/unique_cookie"))
+
+    with Session() as session:
+        session.cache = cache
+        first = session.get(url)
+        second = session.get(url)
+
+    assert first.cookies["foo"] == second.cookies["foo"]
+    assert len(list(tmp_path.glob("*.json"))) == 1
+
+
 def test_session_accepts_int_cache_shorthand():
     session = Session(cache=60)
     try:


### PR DESCRIPTION
Since 0.16.0b1, `Session.__init__` always sets `self.cache` (to `None` when caching is disabled), so `hasattr(session, "cache")` became `True` for every session. Libraries use that check to detect caching sessions (requests_cache's `CachedSession` pattern): yfinance started rejecting its own default curl_cffi session and broke on 0.16.0b1 (ranaroussi/yfinance#2910). On 0.15.x the attribute didn't exist.

This only sets the attribute when a backend is actually configured, restoring the 0.15.x behavior. Internal reads go through `getattr(self, "cache", None)`, and assigning `session.cache = backend` after construction still works (test added).

Closes #809

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
