### PR TITLE
feat: add Session.cache_backend property

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -43,7 +43,7 @@ from ..aio import AsyncCurl
 from ..const import CurlFollow, CurlHttpVersion, CurlInfo, CurlOpt
 from ..curl import Curl, CurlError, CurlMime
 from ..utils import CurlCffiWarning
-from .cache import CacheSpec, normalize_cache_backend
+from .cache import CacheBackend, CacheSpec, normalize_cache_backend
 from .cookies import Cookies, CookieTypes
 from .exceptions import (
     RequestException,
@@ -470,6 +470,11 @@ class BaseSession(Generic[R]):
         if strategy.jitter:
             delay += random.uniform(0.0, strategy.jitter)
         return delay
+
+    @property
+    def cache_backend(self) -> Optional[CacheBackend]:
+        """The configured cache backend, or None when caching is disabled."""
+        return self._cache
 
     @property
     def cookies(self) -> Cookies:

--- a/tests/unittest/test_cache.py
+++ b/tests/unittest/test_cache.py
@@ -173,3 +173,13 @@ def test_session_accepts_timedelta_cache_shorthand():
 def test_session_does_not_expose_cache_attribute():
     with Session() as session:
         assert not hasattr(session, "cache")
+
+
+def test_cache_backend_property(tmp_path):
+    cache = FileCacheBackend(expires=timedelta(seconds=60), path=tmp_path)
+
+    with Session(cache=cache) as session:
+        assert session.cache_backend is cache
+
+    with Session() as session:
+        assert session.cache_backend is None


### PR DESCRIPTION
After 49566d7 the `Session(cache=60)` shorthand leaves no public handle to the backend (no `clear()`, no `expires`). This adds a read-only `cache_backend` property, `None` when caching is disabled. Named so it doesn't trip the `hasattr(session, "cache")` convention from #809.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
