### PR TITLE
fix(aio): handle socket_action errors in _force_timeout

### DIFF
--- a/curl_cffi/aio.py
+++ b/curl_cffi/aio.py
@@ -231,7 +231,15 @@ class AsyncCurl:
         while True:
             if not self._curlm:
                 break
-            self.socket_action(CURL_SOCKET_TIMEOUT, CURL_POLL_NONE)
+            # Never let a socket_action error kill the safeguard; warn and keep going.
+            try:
+                self.socket_action(CURL_SOCKET_TIMEOUT, CURL_POLL_NONE)
+            except Exception:
+                warnings.warn(
+                    "force_timeout: socket_action failed; safeguard continuing",
+                    CurlCffiWarning,
+                    stacklevel=2,
+                )
             await asyncio.sleep(0.1)
 
     def add_handle(self, curl: Curl):

--- a/tests/unittest/test_async.py
+++ b/tests/unittest/test_async.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from curl_cffi import AsyncCurl, Curl, CurlOpt
@@ -44,3 +46,29 @@ async def test_socket_action(server):
 
 
 async def test_process_data(server): ...
+
+
+async def test_force_timeout_error():
+    """socket_action errors should not kill the _force_timeout safeguard."""
+    ac = AsyncCurl()
+
+    calls = {"n": 0, "raised": False}
+    real_socket_action = ac.socket_action
+
+    def flaky_socket_action(sockfd, ev_bitmask):
+        if not calls["raised"]:
+            calls["raised"] = True
+            raise RuntimeError("transient socket_action error")
+        calls["n"] += 1
+        return real_socket_action(sockfd, ev_bitmask)
+
+    ac.socket_action = flaky_socket_action
+
+    # raise once, then keep ticking if the safeguard survived
+    await asyncio.sleep(0.35)
+
+    assert calls["raised"]
+    assert not ac._timeout_checker.done()
+    assert calls["n"] >= 1
+
+    await ac.close()


### PR DESCRIPTION
`_force_timeout` exists to make sure a missing socket or timer event never
stalls indefinitely. It runs in the background and drives
`curl_multi_socket_action` every ~100ms, so if a wakeup is ever missed, the
next tick recovers it.

### Problem

It calls `socket_action()` without handling errors, and `socket_action()`
raises `CurlError` on a non-OK return. Nothing catches it, so the coroutine
ends. It is never restarted, which leaves the safeguard stopped for the rest
of the session. Nothing recovers a missed wakeup after that, so a request
that only needed the next tick to make progress can stall and hang the caller.

### Fix

Handle the error inside `_force_timeout`. If `socket_action()` fails, report
it as a `CurlCffiWarning` and keep the loop running, so the safeguard keeps
doing its job instead of ending on the first error. The request-path calls
that raise `CurlError` on purpose (`add_handle` and similar) are left
unchanged.

### Test

`tests/unittest/test_async.py::test_force_timeout_error` injects one failing
`socket_action` call and checks the safeguard is still running afterward. It
fails on `main` and passes with this change.

### Open question

`process_data` calls `self.socket_action()` the same way, outside its own
`try`, so the same `CurlError` goes unhandled there too. With `_force_timeout`
fixed its next tick recovers that socket, so I left it alone to keep this
small. Want the same handling on `process_data`, or a follow-up?

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
