### PR TITLE
fix: enable ALPN by default in Fingerprint

### DIFF
--- a/curl_cffi/fingerprints.py
+++ b/curl_cffi/fingerprints.py
@@ -368,7 +368,7 @@ class Fingerprint:
     tls_version: str = "1.2"
     tls_ciphers: list[str] = field(default_factory=list)
     # the value is [h2, http/1.1], which will be filled by libcurl
-    tls_alpn: bool = False
+    tls_alpn: bool = True
     tls_alps: bool = False
     tls_cert_compression: list[str] = field(default_factory=list)
     tls_signature_hashes: list[str] = field(default_factory=list)  # .sig_hash_args

--- a/tests/unittest/test_fingerprint_application.py
+++ b/tests/unittest/test_fingerprint_application.py
@@ -27,6 +27,32 @@ def test_apply_fingerprint_does_not_select_http_version():
     assert CurlOpt.HTTP_VERSION not in curl.options
 
 
+def test_apply_fingerprint_enables_alpn_by_default():
+    curl = FakeCurl()
+
+    _apply_fingerprint(
+        curl,
+        Fingerprint(),
+        existing_header_names=set(),
+        default_headers=False,
+    )
+
+    assert curl.options[CurlOpt.SSL_ENABLE_ALPN] == 1
+
+
+def test_apply_fingerprint_can_disable_alpn():
+    curl = FakeCurl()
+
+    _apply_fingerprint(
+        curl,
+        Fingerprint(tls_alpn=False),
+        existing_header_names=set(),
+        default_headers=False,
+    )
+
+    assert curl.options[CurlOpt.SSL_ENABLE_ALPN] == 0
+
+
 def test_apply_fingerprint_strips_padding_extension_from_tls_extension_order():
     curl = FakeCurl()
     fingerprint = Fingerprint(tls_extension_order="0-21-11")


### PR DESCRIPTION
`Fingerprint.tls_alpn` defaults to `False`, and `_apply_fingerprint` sets `SSL_ENABLE_ALPN` from it unconditionally. With ALPN off there's nothing to negotiate h2/h3 with, so `impersonate=Fingerprint(...)` silently falls back to HTTP/1.1 whatever `http_version` you asked for.

Live against [cloudflare-quic.com](cloudflare-quic.com), before / after:

| requested | before | after |
|---|---|---|
| `v2` | HTTP/1.1 | HTTP/2 |
| `v3only` | HTTP/1.1 | HTTP/3 |

No real client turns ALPN off: `tests/pro/conftest.py` already has to pass `tls_alpn=True` by hand. Named targets are unaffected: they're native, so `_apply_fingerprint` never runs for them.

Two tests added, one per direction of the flag.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
