### PR TITLE
fix(curl): compare bytes with bytes, not strings

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -684,11 +684,11 @@ class Curl:
         m = STATUS_LINE_RE.match(status_line)
         if not m:
             return CurlHttpVersion.V1_0, 0, b""
-        if m.group(1) == "2.0":
+        if m.group(1) == b"2.0":
             http_version = CurlHttpVersion.V2_0
-        elif m.group(1) == "1.1":
+        elif m.group(1) == b"1.1":
             http_version = CurlHttpVersion.V1_1
-        elif m.group(1) == "1.0":
+        elif m.group(1) == b"1.0":
             http_version = CurlHttpVersion.V1_0
         else:
             http_version = CurlHttpVersion.NONE


### PR DESCRIPTION
## Summary
`parse_status_line` is currently broken, because it compares bytes with strings, which always return `False`. Therefore, it falls through every branch and always returns `CurlHttpVersion.NONE`.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
