### PR TITLE
fix(models): add type annotations to Response.json()

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -301,7 +301,7 @@ class Response:
             yield chunk
         self._finalize_stream()
 
-    def json(self, **kw):
+    def json(self, **kw: Any) -> Any:
         """return a parsed json object of the content."""
         charset_encoding = self.charset_encoding
         if charset_encoding is not None:


### PR DESCRIPTION
`Response.json()` has no type annotations, which causes strict LSP to infer its type as:
```
(**kw: Unknown) -> (Any | Unknown)
```

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
