### PR TITLE
fix(streams): parameterize RequestData

### DIFF
--- a/curl_cffi/requests/streams.py
+++ b/curl_cffi/requests/streams.py
@@ -13,7 +13,7 @@ from .exceptions import UnrewindableBodyError
 
 RequestData = Union[
     dict[str, str],
-    list[tuple],
+    list[tuple[str, str]],
     str,
     BytesIO,
     bytes,


### PR DESCRIPTION
## Summary

The https://github.com/lexiforest/curl_cffi/commit/277abbafa22b4083362d840e738ef1eb7ac09c38 commit broke the explicit generic parameters I did in #768. Strict LSP again complains about it.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
