### PR TITLE
Fix active socket info on Win64

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -502,7 +502,7 @@ class Curl:
             0x200000: "long*",
             0x300000: "double*",
             0x400000: "struct curl_slist **",
-            0x500000: "long*",
+            0x500000: "uintptr_t*",
             0x600000: "int64_t*",
         }
         ret_cast_option = {
@@ -522,11 +522,18 @@ class Curl:
             return ret_cast_option[option_type]()
 
         c_value = ffi.new(ret_option[option_type])
-        ret = lib.curl_easy_getinfo(self._curl, option, c_value)
+        if option_type == 0x500000:
+            ret = lib._curl_easy_getinfo_socket(self._curl, option, c_value)
+        else:
+            ret = lib.curl_easy_getinfo(self._curl, option, c_value)
         self._check_error(ret, "getinfo", option)
         # cookielist and ssl_engines starts with 0x400000, see also: const.py
         if option_type == 0x400000:
             return slist_to_list(c_value[0])
+        if option_type == 0x500000:
+            socket = int(c_value[0])
+            socket_bad = int(ffi.cast("uintptr_t", -1))
+            return -1 if socket == socket_bad else socket
         if c_value[0] == ffi.NULL:
             return b""
 

--- a/ffi/cdef.c
+++ b/ffi/cdef.c
@@ -1,6 +1,7 @@
 // easy interfaces
 void *curl_easy_init();
 int _curl_easy_setopt(void *curl, int option, void *param);
+int _curl_easy_getinfo_socket(void *curl, int option, uintptr_t *result);
 int curl_easy_getinfo(void *curl, int option, void *ret);
 int curl_easy_perform(void *curl);
 void curl_easy_cleanup(void *curl);

--- a/ffi/shim.c
+++ b/ffi/shim.c
@@ -16,3 +16,12 @@ int _curl_easy_setopt(void* curl, int option, void* parameter) {
     }
     return (int)curl_easy_setopt(curl, (CURLoption)option, parameter);
 }
+
+int _curl_easy_getinfo_socket(void* curl, int option, uintptr_t* result) {
+    curl_socket_t socket;
+    CURLcode ret = curl_easy_getinfo(curl, (CURLINFO)option, &socket);
+    if (ret == CURLE_OK) {
+        *result = (uintptr_t)socket;
+    }
+    return (int)ret;
+}

--- a/ffi/shim.h
+++ b/ffi/shim.h
@@ -1,7 +1,9 @@
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #define CURL_STATICLIB
 #include "curl/curl.h"
 
 int _curl_easy_setopt(void* curl, int option, void* param);
+int _curl_easy_getinfo_socket(void* curl, int option, uintptr_t* result);

--- a/tests/unittest/test_curl.py
+++ b/tests/unittest/test_curl.py
@@ -350,6 +350,21 @@ def test_status_code(server):
     assert c.getinfo(CurlInfo.RESPONSE_CODE) == 200
 
 
+def test_active_socket(server):
+    c = Curl()
+    c.setopt(CurlOpt.URL, str(server.url).encode())
+    c.setopt(CurlOpt.CONNECT_ONLY, 1)
+    c.perform()
+    socket = c.getinfo(CurlInfo.ACTIVESOCKET)
+    assert isinstance(socket, int)
+    assert socket >= 0
+
+
+def test_active_socket_without_connection():
+    c = Curl()
+    assert c.getinfo(CurlInfo.ACTIVESOCKET) == -1
+
+
 def test_response_headers(server):
     c = Curl()
     url = str(server.url.copy_with(path="/set_headers"))


### PR DESCRIPTION
## Description

`CURLINFO_ACTIVESOCKET` returns a `curl_socket_t`. The binding currently routes socket results through `long`, which does not preserve the native socket width on Win64.

This change:

- retrieves the socket through a small C shim using `curl_socket_t`
- transfers the value through `uintptr_t` for CFFI
- preserves `CURL_SOCKET_BAD` as Python `-1`
- adds coverage for connected and unconnected socket lookups

## Testing

- `python -bb -m pytest tests/unittest/test_curl.py -k active_socket -q`
- `python -bb -m pytest tests/unittest -q` (532 passed, 19 skipped)
- `ruff check --exclude issues`
- `ruff format --check curl_cffi/curl.py tests/unittest/test_curl.py`

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
