### PR TITLE
fix(types): restore Session.request return annotation

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -888,7 +888,7 @@ class Session(BaseSession[R]):
         max_recv_speed: int = 0,
         multipart: Optional[CurlMime] = None,
         discard_cookies: bool = False,
-    ):
+    ) -> R:
         """Send the request, see ``requests.request`` for details on parameters."""
 
         self._check_session_closed()


### PR DESCRIPTION
## Summary

Restore the `-> R` return type annotation on the synchronous `Session.request` method.

The annotation was accidentally dropped in ca41cc3572a8dcc9258647a0664b387e01733571 (#689), when the original request implementation was moved to `_request_once` and a retrying `request` wrapper was introduced.

`_request_once` retained its `-> R` annotation, and `AsyncSession.request` is also annotated as returning `R`.

This restores the public API typing without changing runtime behavior.

## Testing

- `ruff check --exclude issues` — passed.
- `ruff format --check --exclude issues` — `curl_cffi/requests/session.py` is unchanged by the formatter (the only reported file, `tests/unittest/test_setopt.py`, is pre-existing and untouched here).
- The runtime test suite was not run locally, as it requires a native libcurl-impersonate build; this change is annotation-only and does not affect runtime behavior.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
