### PR TITLE
fix(headers): drop the priority header when HTTP/1.x is pinned

### DIFF
--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -750,6 +750,16 @@ def set_curl_options(
     # Never send `Expect` header.
     update_header_line(header_lines, "Expect", "", replace=True)
 
+    # Browsers only send the RFC 9218 `priority` header on HTTP/2 and HTTP/3, it has no
+    # HTTP/1.x form. Drop the impersonated default when HTTP/1.x is pinned, see #785.
+    if (
+        default_headers
+        and http_version
+        and normalize_http_version(http_version)
+        in (CurlHttpVersion.V1_0, CurlHttpVersion.V1_1)
+    ):
+        update_header_line(header_lines, "Priority", "")
+
     c.setopt(CurlOpt.HTTPHEADER, [h.encode() for h in header_lines])
 
     # Collect user defined headers if default_headers are to be used.

--- a/tests/unittest/test_setopt.py
+++ b/tests/unittest/test_setopt.py
@@ -259,3 +259,40 @@ def test_interface_name_and_prefixed_values_pass_through(interface):
     curl = _set_interface(interface)
 
     assert curl.options[CurlOpt.INTERFACE] == interface.encode()
+
+
+def _header_lines(headers=None, **kwargs):
+    curl = FakeCurl()
+    utils.set_curl_options(
+        curl,
+        "GET",
+        "https://example.com/",
+        params_list=[None, None],
+        headers_list=[None, headers],
+        cookies_list=[None, None],
+        proxies_list=[None, None],
+        verify_list=[True, None],
+        **kwargs,
+    )
+    return [line.decode() for line in curl.options[CurlOpt.HTTPHEADER]]
+
+
+@pytest.mark.parametrize(
+    "http_version", ["v1", CurlHttpVersion.V1_0, CurlHttpVersion.V1_1]
+)
+def test_priority_header_is_dropped_on_http1(http_version):
+    assert "Priority: " in _header_lines(http_version=http_version)
+
+
+@pytest.mark.parametrize(
+    "http_version", [None, "v2", "v3", CurlHttpVersion.V2_0, CurlHttpVersion.V3]
+)
+def test_priority_header_is_kept_on_http2_and_http3(http_version):
+    assert "Priority: " not in _header_lines(http_version=http_version)
+
+
+def test_explicit_priority_header_is_kept_on_http1():
+    lines = _header_lines(headers={"priority": "u=4"}, http_version="v1")
+
+    assert "priority: u=4" in lines
+    assert "Priority: " not in lines


### PR DESCRIPTION
Addresses the pinned-version half of #785.

## Problem

With an impersonate target and `http_version` pinned to HTTP/1.x, curl_cffi sends `priority: u=0, i`. Real browsers only emit the RFC 9218 Extensible Prioritization signal on HTTP/2 and HTTP/3 — it has no HTTP/1.x form — so the request carries a header the browser it impersonates would never send on that connection.

Reproduced on `main` (0.16.1b1, libcurl-impersonate 2.1.0) against a local HTTP/1.1 server, `impersonate="chrome"`:

| case | before | after |
| --- | --- | --- |
| `http_version=CurlHttpVersion.V1_1` | `priority: u=0, i` | absent |
| `http_version="v1"` | `priority: u=0, i` | absent |
| server negotiates 1.1, no pin | `priority: u=0, i` | `priority: u=0, i` (unchanged, see Scope) |

## Change

When `default_headers` is on and `http_version` normalizes to `V1_0`/`V1_1`, add the "disable this header" line for `Priority` to `header_lines` — the same mechanism `Expect` already uses one line above.

Two things follow from where it sits, both intentional:

- it is added before `existing_header_names` is computed, so it covers the `_apply_fingerprint` path as well as native impersonation, without a second edit;
- `update_header_line` is called without `replace`, so an explicitly passed `priority` header still wins.

I verified the sentinel actually suppresses the natively injected header rather than just being ignored — with it, `priority` is gone and the other 13 impersonated headers are untouched.

## Scope

This covers only the case where the caller pins HTTP/1.x, which is the part the Python layer can decide. When a server negotiates down to HTTP/1.1 via ALPN, the protocol is chosen inside libcurl after the header list is already set, so the header set would have to become protocol-aware in curl-impersonate itself. Left out deliberately rather than half-guessed, and the commit says `Refs #785` rather than closing it.

## Tests

`tests/unittest/test_setopt.py`, following the existing `FakeCurl` pattern, no network:

- dropped on HTTP/1.x, for `"v1"`, `V1_0` and `V1_1`
- not dropped on HTTP/2, HTTP/3, or when `http_version` is unset
- a user-supplied `priority` header is preserved

All three fail without the change.

`make test`: 539 passed, 19 skipped. `make lint`: clean. `ruff format` leaves both touched files alone (the two files that do drift on `main` were left untouched to keep the diff focused).

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
