### PR TITLE
fix(build): ship an Android wheel per CPython minor, add 3.14

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -108,11 +108,17 @@ jobs:
       uses: pypa/cibuildwheel@v3.3.1
       env:
         CIBW_PLATFORM: android
-        # One wheel per CPython minor: Android extensions link libpython3.X.so by
-        # SONAME, so an abi3 wheel does not carry over to the next version.
+        # One wheel per CPython minor, see the Android note in setup.py.
         CIBW_BUILD: cp313-android_arm64_v8a cp314-android_arm64_v8a
         ANDROID_HOME: ${{ env.ANDROID_SDK_ROOT }}
         ANDROID_API_LEVEL: 24
+
+    # cibuildwheel silently reuses an abi3 wheel for a later interpreter, so a
+    # missing wheel would otherwise leave this job green.
+    - name: Check one wheel was built per CPython minor
+      run: |
+        ls -l ./wheelhouse/
+        for tag in cp313 cp314; do ls ./wheelhouse/*-$tag-*-android_*.whl; done
 
     - uses: actions/upload-artifact@v4  # https://github.com/actions/upload-artifact/issues/478
       with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -108,7 +108,9 @@ jobs:
       uses: pypa/cibuildwheel@v3.3.1
       env:
         CIBW_PLATFORM: android
-        CIBW_BUILD: cp313-android_arm64_v8a
+        # One wheel per CPython minor: Android extensions link libpython3.X.so by
+        # SONAME, so an abi3 wheel does not carry over to the next version.
+        CIBW_BUILD: cp313-android_arm64_v8a cp314-android_arm64_v8a
         ANDROID_HOME: ${{ env.ANDROID_SDK_ROOT }}
         ANDROID_API_LEVEL: 24
 

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,15 @@ class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self):
         python, abi, plat = super().get_tag()
 
-        if python.startswith("cp") and not (python.endswith("t") or abi.endswith("t")):
-            if "android" in plat:
-                # cibuildwheel supports android since cp313, so we can't mark it as 310
-                return python, "abi3", plat
+        # Android extension modules link libpython3.X.so by SONAME, so they are not
+        # stable-ABI across minor versions even though they are built against the
+        # limited API. Keep the real tag there and ship one wheel per CPython minor,
+        # otherwise pip installs the 3.13 wheel on 3.14 and the import fails, see #824.
+        if (
+            python.startswith("cp")
+            and not (python.endswith("t") or abi.endswith("t"))
+            and "android" not in plat
+        ):
             # On CPython, our wheels are abi3 and compatible back to 3.10.
             # Free-threaded builds ("t" tag) must keep their original tags (PEP 803).
             # Once PEP 803 is accepted, we may be able to build abi3t wheels.


### PR DESCRIPTION
Close #824.

## Problem

The published Android wheel is `curl_cffi-0.16.0-cp313-abi3-android_24_arm64_v8a.whl`, but the extension inside it is not stable-ABI:

```
$ readelf -d curl_cffi/_wrapper.abi3.so | grep NEEDED
 (NEEDED)  Shared library: [libm.so]
 (NEEDED)  Shared library: [libpython3.13.so]
 (NEEDED)  Shared library: [libc++_shared-d523468d.so]
 ...
```

Unlike Linux and macOS, where an extension resolves Python symbols from the already-loaded interpreter, an Android extension links `libpython3.X.so` by SONAME. `Py_LIMITED_API` does not change that — there is no `libpython3.so` forwarder to link against — so the `abi3` tag promises portability the file does not have.

`packaging.tags` on 3.14 lists `cp313-abi3-android_24_arm64_v8a` as compatible, so pip installs that wheel and the import fails with the error from the issue:

```
ImportError: dlopen failed: library "libpython3.13.so" not found:
needed by .../site-packages/curl_cffi/_wrapper.abi3.so
```

## Change

Two commits:

1. add `cp314-android_arm64_v8a` to `CIBW_BUILD`;
2. stop forcing the `abi3` tag for Android in `setup.py`, and fail the job if a wheel is missing.

The second commit is what makes the first one take effect. With the `abi3` tag in place cibuildwheel reuses the first wheel and never runs the second build:

```
Building cp313-android_arm64_v8a wheel
...
Building cp314-android_arm64_v8a wheel
Found previously built wheel curl_cffi-0.16.1b1-cp313-abi3-android_24_arm64_v8a.whl
that is compatible with cp314-android_arm64_v8a. Skipping build step...
```

That log is from the first commit on this PR — the job stayed green and still uploaded a single cp313 wheel, which is why the workflow now asserts one wheel per minor instead of trusting the exit code.

Other platforms are untouched: `cp310-abi3` on Linux/macOS/Windows and `cp314-cp314t` for free-threaded builds keep their current tags. Android now produces `cp313-cp313-...` and `cp314-cp314-...`.

## Effect on users

- 3.13: same wheel as today, different tag.
- 3.14: gets a working wheel instead of a broken 3.13 one.
- A future minor with no wheel yet: clean `no matching distribution` from pip instead of an `ImportError` after a successful install.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
