### PR TITLE
fix(fingerprints): warn when a fingerprint carries no headers

### DIFF
--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -544,6 +544,19 @@ def _apply_fingerprint(
             ",".join(fingerprint.ws_tls_cert_compression),
         )
 
+    # Fingerprints from the open source target list carry no headers at all, so
+    # impersonation would silently degrade to a header-less request, see #826.
+    if default_headers and not (
+        fingerprint.headers or fingerprint.http3_headers or fingerprint.ws_headers
+    ):
+        name = f"{fingerprint.client}{fingerprint.client_version}" or "The fingerprint"
+        warnings.warn(
+            f"{name} has no headers, the request is sent without impersonated "
+            "default headers. Pass headers explicitly to silence this warning.",
+            CurlCffiWarning,
+            stacklevel=2,
+        )
+
     # default headers will not override user-defined headers
     if default_headers and fingerprint.headers:
         header_lines = []

--- a/tests/unittest/test_fingerprint_application.py
+++ b/tests/unittest/test_fingerprint_application.py
@@ -1,8 +1,13 @@
+import warnings
+
+import pytest
+
 from curl_cffi.const import CurlOpt
 from curl_cffi.fingerprints import Fingerprint
 from curl_cffi.requests.impersonate import ExtraFingerprints
 from curl_cffi.requests.utils import _apply_fingerprint
 from curl_cffi.requests.utils import set_extra_fp
+from curl_cffi.utils import CurlCffiWarning
 
 
 class FakeCurl:
@@ -173,3 +178,48 @@ def test_set_extra_fp_sets_header_order():
     set_extra_fp(curl, extra_fp)
 
     assert curl.options[CurlOpt.HTTPHEADER_ORDER] == "User-Agent,Host,Connection"
+
+
+def test_apply_fingerprint_warns_when_fingerprint_has_no_headers():
+    curl = FakeCurl()
+    fingerprint = Fingerprint(client="chrome", client_version="146")
+
+    with pytest.warns(CurlCffiWarning, match="chrome146 has no headers"):
+        _apply_fingerprint(
+            curl,
+            fingerprint,
+            existing_header_names=set(),
+            default_headers=True,
+        )
+
+    assert CurlOpt.HTTPHEADER not in curl.options
+
+
+def test_apply_fingerprint_does_not_warn_when_headers_are_present():
+    curl = FakeCurl()
+    fingerprint = Fingerprint(headers={"user-agent": "curl"})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", CurlCffiWarning)
+        _apply_fingerprint(
+            curl,
+            fingerprint,
+            existing_header_names=set(),
+            default_headers=True,
+        )
+
+    assert curl.options[CurlOpt.HTTPHEADER] == [b"user-agent: curl"]
+
+
+def test_apply_fingerprint_does_not_warn_without_default_headers():
+    curl = FakeCurl()
+    fingerprint = Fingerprint()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", CurlCffiWarning)
+        _apply_fingerprint(
+            curl,
+            fingerprint,
+            existing_header_names=set(),
+            default_headers=False,
+        )


### PR DESCRIPTION
Close #826.

## Problem

If you pass a `Fingerprint` object instead of a target name, the request goes out with no impersonated headers. The header block in `_apply_fingerprint` is guarded by `if default_headers and fingerprint.headers:`, and the fingerprints in the open source list don't have any:

```
chrome131:  headers=0  http3_headers=0  ws_headers=0
chrome146:  headers=0  http3_headers=0  ws_headers=0
firefox133: headers=0  http3_headers=0  ws_headers=0
```

Nothing errors out and TLS still matches the browser, so there's no sign anything is off. You just end up sending a header set no browser would send. If you pick a fingerprint at random from `list_fingerprints()` like the issue describes, you won't notice.

## Change

Warn when `default_headers` is on and the fingerprint has no headers.

I kept the check quiet if the fingerprint has headers of any kind, including `http3_headers` and `ws_headers`. That still covers the case from the issue, and it means the synthetic fingerprint in `test_apply_fingerprint_sets_http3_and_websocket_options` doesn't start warning, so I didn't have to touch any existing test.

This is a stopgap, not a real fix. Shipping headers with the open source fingerprints would solve it properly, and nothing here gets in the way of that.

## Tests

Three cases in `tests/unittest/test_fingerprint_application.py`: a header-less fingerprint warns, a fingerprint with headers doesn't, and `default_headers=False` doesn't either. All three fail without the change with `DID NOT WARN`.

`make test`: 535 passed, 19 skipped. `make lint` is clean.

One thing worth flagging: two existing tests in `test_setopt.py` now print the warning, because they load a bundled fingerprint. That's the bug showing up, not noise from this change.

## Checklist

- [x] I have manually reviewed the changes and fully understand the code.
