### PR TITLE
Use RTLD_DEEPBIND when loading the native extension

### DIFF
--- a/curl_cffi/__init__.py
+++ b/curl_cffi/__init__.py
@@ -49,12 +49,35 @@ __all__ = [
     "exceptions",
 ]
 
+# flake8: noqa: E402
+# The RTLD_DEEPBIND setup below runs before the rest of this file's imports
+# by necessity (it must wrap the first import that touches _wrapper), which
+# pushes every import after it out of flake8's "top of file" rule.
+import os
+import sys
+
 import _cffi_backend  # noqa: F401  # required by _wrapper
 
-from .__version__ import __curl_version__, __description__, __title__, __version__  # noqa: F401
+# Use RTLD_DEEPBIND to prevent BoringSSL symbol collisions with host OpenSSL.
+# Must wrap __version__ import as it resolves curl version and loads _wrapper.
+_prev_dlopen_flags = None
+if hasattr(sys, "setdlopenflags") and hasattr(os, "RTLD_DEEPBIND"):
+    _prev_dlopen_flags = sys.getdlopenflags()
+    sys.setdlopenflags(os.RTLD_NOW | os.RTLD_DEEPBIND)
 
-# This line includes _wrapper.so into the wheel
-from ._wrapper import ffi, lib
+try:
+    from .__version__ import (  # noqa: F401
+        __curl_version__,
+        __description__,
+        __title__,
+        __version__,
+    )
+
+    # This line includes _wrapper.so into the wheel
+    from ._wrapper import ffi, lib
+finally:
+    if _prev_dlopen_flags is not None:
+        sys.setdlopenflags(_prev_dlopen_flags)
 from .aio import AsyncCurl
 from .const import (
     CurlECode,


### PR DESCRIPTION
curl_cffi bundles libcurl-impersonate, which is statically linked
against BoringSSL. BoringSSL deliberately keeps OpenSSL's public
symbol names (SSL_new, EVP_*, X509_*, ...) for drop-in compatibility,
even though the two are ABI-incompatible.

When curl_cffi is imported inside a host process that has already
linked its own system OpenSSL -- e.g. an application embedding a
Python interpreter, such as Kodi -- default ELF global-scope symbol
resolution is first-loaded-wins. BoringSSL's internal calls can get
silently rebound to the host's already-loaded OpenSSL instead of its
own, breaking impersonation (or worse) in ways that are otherwise very
hard to diagnose: the standalone package works fine, the failure only
reproduces inside the host process, and errors surface as ordinary-
looking curl error codes with no indication of the real cause.

RTLD_DEEPBIND makes the newly-loaded extension prefer its own symbols
over the process's global scope when resolving its internal
references, which is exactly the failure direction here.

The flag must be set around the *first* import that touches _wrapper,
not just the "This line includes _wrapper.so into the wheel" import
below it: `__version__.py`'s own `_resolve_curl_version()` does
`from ._wrapper import ffi, lib` too, and `__init__.py` imports
`.__version__` before reaching that line -- so the real first native
load happens there, unprotected, if only the later import is wrapped.

Verified against a real embedding scenario (Kodi): the identical
package succeeds standalone and fails consistently inside the host
process without this change, and succeeds with it.

- [x] I have manually reviewed the changes and fully understand the code.
