### PR TITLE
Add support for compiling against system-wide libcurl-impersonate

### DIFF
--- a/curl_cffi/requests/impersonate.py
+++ b/curl_cffi/requests/impersonate.py
@@ -1,6 +1,7 @@
+import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal, Optional, TypedDict
+from typing import Literal, Optional, TypedDict, get_args
 
 from ..const import CurlSslVersion
 
@@ -123,6 +124,33 @@ def resolve_latest_browser_type(item):
         return DEFAULT_TOR
     else:
         return item
+
+
+_FAMILY_PATTERNS = {
+    "chrome": r"^chrome\d+[a-z]?$",
+    "edge": r"^edge\d+$",
+    "safari": r"^safari\d+$",
+    "safari_ios": r"^safari\d+_ios$",
+    "safari_beta": r"^safari\d+$",
+    "safari_ios_beta": r"^safari\d+_ios$",
+    "chrome_android": r"^chrome\d+_android$",
+    "firefox": r"^firefox\d+$",
+    "tor": r"^tor\d+$",
+}
+
+
+def has_family_fallback(alias):
+    return alias in _FAMILY_PATTERNS
+
+
+def family_fallback_targets(alias):
+    # Derived from BrowserTypeLiteral (already chronological) instead of a
+    # second list, so it can't drift out of sync.
+    pattern = _FAMILY_PATTERNS.get(alias)
+    if not pattern:
+        return []
+    regex = re.compile(pattern)
+    return [t for t in reversed(get_args(BrowserTypeLiteral)) if regex.match(t)]
 
 
 class BrowserType(str, Enum):  # TODO: remove in version 1.x

--- a/curl_cffi/requests/utils.py
+++ b/curl_cffi/requests/utils.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Union, cast, fi
 from urllib.parse import ParseResult, parse_qsl, quote, urlencode, urljoin, urlparse
 
 from ..const import CurlFollow, CurlHttpVersion, CurlOpt, CurlSslVersion
-from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
+from ..curl import CURL_WRITEFUNC_ERROR, Curl, CurlMime
 from ..utils import CurlCffiWarning, HttpVersionLiteral
 from ..fingerprints import Fingerprint, FingerprintManager, NATIVE_IMPERSONATE_TARGETS
 from .cookies import Cookies
@@ -27,6 +27,8 @@ from .impersonate import (
     TLS_EC_CURVES_MAP,
     TLS_VERSION_MAP,
     ExtraFingerprints,
+    family_fallback_targets,
+    has_family_fallback,
     resolve_latest_browser_type,
 )
 from .models import Request
@@ -404,6 +406,43 @@ def _load_named_fingerprint(target: str) -> Optional[Fingerprint]:
 def _is_native_impersonate_target(target: str) -> bool:
     normalized = resolve_latest_browser_type(target)
     return normalized in NATIVE_TARGET_NAMES
+
+
+# Per-process, not per-Session: the linked libcurl-impersonate can't change
+# mid-process.
+_alias_fallback_cache: dict[str, Optional[str]] = {}
+
+
+def _resolve_impersonate_with_fallback(
+    alias: str, failed_target: str, default_headers: bool
+) -> Optional[str]:
+    # A system-provided libcurl-impersonate (CURL_IMPERSONATE_SYSTEM) may not
+    # support this release's hardcoded default. Probe on a throwaway handle,
+    # not the caller's, so a failed attempt can't leave it in a partial state.
+    if alias in _alias_fallback_cache:
+        return _alias_fallback_cache[alias]
+
+    probe = Curl()
+    try:
+        for candidate in family_fallback_targets(alias):
+            if candidate == failed_target:
+                continue
+            if probe.impersonate(candidate, default_headers=False) == 0:
+                _alias_fallback_cache[alias] = candidate
+                warnings.warn(
+                    f"curl_cffi: impersonate={alias!r} resolves to "
+                    f"{failed_target!r} by default, which the linked "
+                    f"libcurl-impersonate doesn't support; falling back to "
+                    f"{candidate!r} instead.",
+                    CurlCffiWarning,
+                    stacklevel=3,
+                )
+                return candidate
+    finally:
+        probe.close()
+
+    _alias_fallback_cache[alias] = None
+    return None
 
 
 def _strip_padding_extension(extension_order: str) -> str:
@@ -925,6 +964,13 @@ def set_curl_options(
             if _is_native_impersonate_target(impersonate):
                 normalized = resolve_latest_browser_type(impersonate)
                 ret = c.impersonate(normalized, default_headers=default_headers)  # type: ignore
+                if ret != 0 and has_family_fallback(impersonate):
+                    fallback = _resolve_impersonate_with_fallback(
+                        impersonate, normalized, default_headers
+                    )
+                    if fallback is not None:
+                        ret = c.impersonate(fallback, default_headers=default_headers)  # type: ignore
+                        normalized = fallback
                 if ret != 0:
                     raise ImpersonateError(
                         f"Impersonating {normalized} is not supported"

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -92,14 +92,40 @@ def get_obj_name(arch, link_type):
     return "libcurl-impersonate.dll"
 
 
-arch = detect_arch()
-link_type = get_link_type(arch)
-obj_name = get_obj_name(arch, link_type)
-libdir = Path(arch["libdir"])
-is_static = link_type == "static"
-is_dynamic = link_type == "dynamic"
-is_android = arch.get("libc") == "android"
-print(f"Using {libdir} to store libcurl-impersonate")
+is_system = os.environ.get("CURL_IMPERSONATE_SYSTEM") == "1"
+if is_system:
+    import subprocess
+    try:
+        inc_dirs = [
+            p[2:] for p in subprocess.check_output(
+                ["pkg-config", "--cflags-only-I", "libcurl-impersonate"], text=True
+            ).split() if p.startswith("-I")
+        ]
+        libs = [
+            p[2:] for p in subprocess.check_output(
+                ["pkg-config", "--libs-only-l", "libcurl-impersonate"], text=True
+            ).split() if p.startswith("-l")
+        ]
+    except Exception:
+        inc_dirs = ["/usr/include/curl-impersonate"]
+        libs = ["curl-impersonate"]
+
+    arch = {"system": "Linux"}
+    is_static = False
+    is_dynamic = True
+    is_android = False
+    libdir = Path("")
+else:
+    inc_dirs = []
+    libs = []
+    arch = detect_arch()
+    link_type = get_link_type(arch)
+    obj_name = get_obj_name(arch, link_type)
+    libdir = Path(arch["libdir"])
+    is_static = link_type == "static"
+    is_dynamic = link_type == "dynamic"
+    is_android = arch.get("libc") == "android"
+    print(f"Using {libdir} to store libcurl-impersonate")
 
 
 def download_libcurl():
@@ -182,7 +208,8 @@ def get_curl_libraries():
 ffibuilder = FFI()
 system = platform.system()
 root_dir = Path(__file__).parent.parent
-download_libcurl()
+if not is_system:
+    download_libcurl()
 
 # With mega archive, we only have one to link
 static_libs = get_curl_archives()
@@ -214,25 +241,24 @@ ffibuilder.set_source(
     """
         #include "shim.h"
     """,
-    library_dirs=[str(libdir)],
-    runtime_library_dirs=(
+    library_dirs=[] if is_system else [str(libdir)],
+    runtime_library_dirs=[] if is_system else (
         [str(libdir)] if is_dynamic and arch["system"] != "Windows" else []
     ),
-    libraries=get_curl_libraries(),
+    libraries=libs if is_system else get_curl_libraries(),
     extra_objects=[],  # linked via extra_link_args
     source_extension=".c",
     include_dirs=[
         str(root_dir / "include"),
         str(root_dir / "ffi"),
-        str(libdir / "include"),
-    ],
+    ] + (inc_dirs if is_system else [str(libdir / "include")]),
     sources=[
         str(root_dir / "ffi/shim.c"),
     ],
     extra_compile_args=(
         ["-Wno-implicit-function-declaration"] if system == "Darwin" else []
     ),
-    extra_link_args=extra_link_args,
+    extra_link_args=[] if is_system else extra_link_args,
 )
 
 with open(root_dir / "ffi/cdef.c") as f:


### PR DESCRIPTION
Introduces CURL_IMPERSONATE_SYSTEM=1 environment variable to bypass the automatic architecture-detection and downloading of prebuilt static binaries, allowing Linux distributions and package maintainers to link against the system's libcurl-impersonate using pkg-config. If the environment variable is not defined, the build behavior defaults to the standard bundling and downloading process.

[x] I have manually reviewed the changes and fully understand the code.