### PR TITLE
Add Android cross-ABI target support

### DIFF
--- a/libs.json
+++ b/libs.json
@@ -98,6 +98,36 @@
         "arch": "aarch64"
     },
     {
+        "system": "Android",
+        "machine": "x86_64",
+        "pointer_size": 64,
+        "sysname": "linux-android",
+        "link_type": "static",
+        "libc": "android",
+        "obj_name": "libcurl-impersonate.a",
+        "arch": "x86_64"
+    },
+    {
+        "system": "Android",
+        "machine": "i686",
+        "pointer_size": 32,
+        "sysname": "linux-android",
+        "link_type": "static",
+        "libc": "android",
+        "obj_name": "libcurl-impersonate.a",
+        "arch": "x86"
+    },
+    {
+        "system": "Android",
+        "machine": "armv7l",
+        "pointer_size": 32,
+        "sysname": "linux-android",
+        "link_type": "static",
+        "libc": "android",
+        "obj_name": "libcurl-impersonate.a",
+        "arch": "armv7"
+    },
+    {
         "system": "Linux",
         "machine": "riscv64",
         "pointer_size": 64,

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -32,20 +32,28 @@ def detect_arch():
         archs = json.loads(f.read())
 
     uname = platform.uname()
+
+    machine = os.environ.get("CURL_CFFI_TARGET_MACHINE", uname.machine)
+    pointer_size = int(
+        os.environ.get(
+            "CURL_CFFI_TARGET_POINTER_SIZE",
+            struct.calcsize("P") * 8,
+        )
+    )
+
     uname_system = "Android" if is_android_env() else uname.system
-    glibc_flavor = "gnueabihf" if uname.machine in ["armv7l", "armv6l"] else "gnu"
+    glibc_flavor = "gnueabihf" if machine in ["armv7l", "armv6l"] else "gnu"
 
     libc, _ = platform.libc_ver()
     # https://github.com/python/cpython/issues/87414
     libc = glibc_flavor if libc == "glibc" else "musl"
     if is_android_env():
         libc = "android"
-    pointer_size = struct.calcsize("P") * 8
 
     for arch in archs:
         if (
             arch["system"] == uname_system
-            and arch["machine"] == uname.machine
+            and arch["machine"] == machine
             and arch["pointer_size"] == pointer_size
             and ("libc" not in arch or arch.get("libc") == libc)
         ):


### PR DESCRIPTION
## Checklist

- [x] I have manually reviewed the changes and fully understand the code.

Adds Android x86_64, x86, and armv7 target definitions and allows cross-builds to override the detected machine and pointer size, so curl_cffi can select the correct Android target when the build host architecture differs from the target architecture.